### PR TITLE
PEP8 fixing of spaces/tabs and adding ".fq.gz"

### DIFF
--- a/expt_config_parser.py
+++ b/expt_config_parser.py
@@ -2,183 +2,198 @@ from configparser import ConfigParser
 import os
 import fnmatch
 
-#Parse and validate the input of an experiment config file
-#output a dict with all of the parameters needed to process experiments
+# Parse and validate the input of an experiment config file
+# output a dict with all of the parameters needed to process experiments
+
+
 def parseExptConfig(configFile, librariesToSublibrariesDict):
     parser = ConfigParser()
     results = parser.read(configFile)
     if len(results) == 0:
         return None, 1, 'Experiment config file not found'
-    
-    #output variables
+
+    # output variables
     paramDict = dict()
     exitStatus = 0
     warningString = ''
 
-    ##check all sections
+    # check all sections
     expectedSections = set(['experiment_settings',
-         'library_settings',
-         'counts_files',
-         'filter_settings',
-         'sgrna_analysis',
-         'growth_values',
-         'gene_analysis'])
-         
+                            'library_settings',
+                            'counts_files',
+                            'filter_settings',
+                            'sgrna_analysis',
+                            'growth_values',
+                            'gene_analysis'])
+
     parsedSections = set(parser.sections())
-    
+
     if len(expectedSections) != len(parsedSections) and len(expectedSections) != len(expectedSections.intersection(parsedSections)):
         return paramDict, 1, 'Config file does not have all required sections or has extraneous sections!\nExpected:' + ','.join(expectedSections) + '\nFound:' + ','.join(parsedSections)
 
-    ##experiment settings
-    if parser.has_option('experiment_settings','output_folder'):
-        paramDict['output_folder'] = parser.get('experiment_settings','output_folder') #ways to check this is a valid path?
+    # experiment settings
+    if parser.has_option('experiment_settings', 'output_folder'):
+        # ways to check this is a valid path?
+        paramDict['output_folder'] = parser.get(
+            'experiment_settings', 'output_folder')
     else:
         warningString += 'No output folder specified, defaulting to current directory\n.'
         paramDict['output_folder'] = os.curdir()
-        
-    if parser.has_option('experiment_settings','experiment_name'):
-        paramDict['experiment_name'] = parser.get('experiment_settings','experiment_name')
+
+    if parser.has_option('experiment_settings', 'experiment_name'):
+        paramDict['experiment_name'] = parser.get(
+            'experiment_settings', 'experiment_name')
     else:
         warningString += 'No experiment name specified, defaulting to \'placeholder_expt_name\'\n.'
         paramDict['experiment_name'] = 'placeholder_expt_name'
-        
-        
-    ##library settings
+
+    # library settings
     libraryDict = librariesToSublibrariesDict
-    if parser.has_option('library_settings','library'):
-        parsedLibrary = parser.get('library_settings','library')
-        
+    if parser.has_option('library_settings', 'library'):
+        parsedLibrary = parser.get('library_settings', 'library')
+
         if parsedLibrary.lower() in libraryDict:
             paramDict['library'] = parsedLibrary.lower()
         else:
             warningString += 'Library name \"%s\" not recognized\n' % parsedLibrary
             exitStatus += 1
-            
+
     else:
         warningString += 'No library specified\n'
         exitStatus += 1
         parsedLibrary = ''
-      
+
     if 'library' in paramDict:
-        if parser.has_option('library_settings','sublibraries'):
-            parsedSubList = parser.get('library_settings','sublibraries').strip().split('\n')
-            
+        if parser.has_option('library_settings', 'sublibraries'):
+            parsedSubList = parser.get(
+                'library_settings', 'sublibraries').strip().split('\n')
+
             paramDict['sublibraries'] = []
-            
+
             for sub in parsedSubList:
                 sub = sub.lower()
                 if sub in libraryDict[paramDict['library']]:
                     paramDict['sublibraries'].append(sub)
-                    
+
                 else:
                     warningString += 'Sublibrary %s not recognized\n' % sub
-                    
+
         else:
             paramDict['sublibraries'] = libraryDict[paramDict['library']]
-            
-    
-    ##counts files
-    if parser.has_option('counts_files','counts_file_string'):
-        countsFileString = parser.get('counts_files','counts_file_string').strip()
-        
+
+    # counts files
+    if parser.has_option('counts_files', 'counts_file_string'):
+        countsFileString = parser.get(
+            'counts_files', 'counts_file_string').strip()
+
         paramDict['counts_file_list'] = []
-        
+
         for stringLine in countsFileString.split('\n'):
             stringLine = stringLine.strip()
-            
+
             if len(stringLine.split(':')) != 2 or len(stringLine.split('|')) != 2:
                 warningString += 'counts file entry could not be parsed: ' + stringLine + '\n'
                 exitStatus += 1
-            
+
             else:
                 parsedPath = stringLine.split(':')[0]
-                
+
                 if os.path.isfile(parsedPath) == False:
                     warningString += 'Counts file not found: ' + parsedPath + '\n'
                     exitStatus += 1
-                    
+
                 condition, replicate = stringLine.split(':')[1].split('|')
-                
-                paramDict['counts_file_list'].append((condition, replicate,parsedPath))
-            
+
+                paramDict['counts_file_list'].append(
+                    (condition, replicate, parsedPath))
+
     else:
         warningString += 'No counts files entered\n'
         exitStatus += 1
-        
-    
-    ##filter settings
-    filterOptions = ['either','both']
-    if parser.has_option('filter_settings','filter_type') and parser.get('filter_settings','filter_type').lower() in filterOptions:
-        paramDict['filter_type'] = parser.get('filter_settings','filter_type').lower()
+
+    # filter settings
+    filterOptions = ['either', 'both']
+    if parser.has_option('filter_settings', 'filter_type') and parser.get('filter_settings', 'filter_type').lower() in filterOptions:
+        paramDict['filter_type'] = parser.get(
+            'filter_settings', 'filter_type').lower()
     else:
         warningString += 'Filter type not set or not recognized, defaulting to \'either\'\n'
         paramDict['filter_type'] = 'either'
-        
-    if parser.has_option('filter_settings','minimum_reads'):
+
+    if parser.has_option('filter_settings', 'minimum_reads'):
         try:
-            paramDict['minimum_reads'] = parser.getint('filter_settings','minimum_reads')
+            paramDict['minimum_reads'] = parser.getint(
+                'filter_settings', 'minimum_reads')
         except ValueError:
-            warningString += 'Minimum read value not an integer, defaulting to 0\n'  #recommended value is 50 but seems arbitrary to default to that
+            # recommended value is 50 but seems arbitrary to default to that
+            warningString += 'Minimum read value not an integer, defaulting to 0\n'
             paramDict['minimum_reads'] = 0
     else:
-        warningString += 'Minimum read value not found, defaulting to 0\n'  #recommended value is 50 but seems arbitrary to default to that
+        # recommended value is 50 but seems arbitrary to default to that
+        warningString += 'Minimum read value not found, defaulting to 0\n'
         paramDict['minimum_reads'] = 0
 
-
-    ##sgRNA Analysis
-    if parser.has_option('sgrna_analysis','condition_string'):
-        conditionString = parser.get('sgrna_analysis','condition_string').strip()
+    # sgRNA Analysis
+    if parser.has_option('sgrna_analysis', 'condition_string'):
+        conditionString = parser.get(
+            'sgrna_analysis', 'condition_string').strip()
 
         paramDict['condition_tuples'] = []
-        
+
         if 'counts_file_list' in paramDict:
-            expectedConditions = set(list(zip(*paramDict['counts_file_list']))[0])
+            expectedConditions = set(
+                list(zip(*paramDict['counts_file_list']))[0])
         else:
             expectedConditions = []
 
         enteredConditions = set()
-        
+
         for conditionStringLine in conditionString.split('\n'):
             conditionStringLine = conditionStringLine.strip()
 
             if len(conditionStringLine.split(':')) != 3:
-                warningString += 'Phenotype condition line not understood: ' + conditionStringLine + '\n'
+                warningString += 'Phenotype condition line not understood: ' + \
+                    conditionStringLine + '\n'
                 exitStatus += 1
             else:
-                phenotype, condition1, condition2 = conditionStringLine.split(':')
+                phenotype, condition1, condition2 = conditionStringLine.split(
+                    ':')
 
                 if condition1 not in expectedConditions or condition2 not in expectedConditions:
-                    warningString += 'One of the conditions entered does not correspond to a counts file: ' + conditionStringLine + '\n'
+                    warningString += 'One of the conditions entered does not correspond to a counts file: ' + \
+                        conditionStringLine + '\n'
                     exitStatus += 1
                 else:
-                    paramDict['condition_tuples'].append((phenotype,condition1,condition2))
+                    paramDict['condition_tuples'].append(
+                        (phenotype, condition1, condition2))
                     enteredConditions.add(condition1)
                     enteredConditions.add(condition2)
 
         if len(paramDict['condition_tuples']) == 0:
             warningString += 'No phenotype score/condition pairs found\n'
             exitStatus += 1
-            
+
         unusedConditions = list(expectedConditions - enteredConditions)
         if len(unusedConditions) > 0:
             warningString += 'Some conditions assigned to counts files will not be incorporated in sgRNA analysis:\n' \
                 + ','.join(unusedConditions) + '\n'
-        
+
     else:
         warningString += 'No phenotype score/condition pairs entered\n'
         exitStatus += 1
-    
-    
-    pseudocountOptions = ['zeros only','all values','filter out']
-    if parser.has_option('sgrna_analysis','pseudocount_behavior') and parser.get('sgrna_analysis','pseudocount_behavior').lower() in pseudocountOptions:
-        paramDict['pseudocount_behavior'] = parser.get('sgrna_analysis','pseudocount_behavior').lower()
+
+    pseudocountOptions = ['zeros only', 'all values', 'filter out']
+    if parser.has_option('sgrna_analysis', 'pseudocount_behavior') and parser.get('sgrna_analysis', 'pseudocount_behavior').lower() in pseudocountOptions:
+        paramDict['pseudocount_behavior'] = parser.get(
+            'sgrna_analysis', 'pseudocount_behavior').lower()
     else:
         warningString += 'Pseudocount behavior not set or not recognized, defaulting to \'zeros only\'\n'
         paramDict['pseudocount_behavior'] = 'zeros only'
 
-    if parser.has_option('sgrna_analysis','pseudocount'):
+    if parser.has_option('sgrna_analysis', 'pseudocount'):
         try:
-            paramDict['pseudocount'] = parser.getfloat('sgrna_analysis','pseudocount')
+            paramDict['pseudocount'] = parser.getfloat(
+                'sgrna_analysis', 'pseudocount')
         except ValueError:
             warningString += 'Pseudocount value not an number, defaulting to 0.1\n'
             paramDict['pseudocount'] = 0.1
@@ -186,39 +201,41 @@ def parseExptConfig(configFile, librariesToSublibrariesDict):
         warningString += 'Pseudocount value not found, defaulting to 0.1\n'
         paramDict['pseudocount'] = 0.1
 
-    
-    ##Growth Values
-    if parser.has_option('growth_values','growth_value_string') and len(parser.get('growth_values','growth_value_string').strip()) != 0:
-        growthValueString = parser.get('growth_values','growth_value_string').strip()
+    # Growth Values
+    if parser.has_option('growth_values', 'growth_value_string') and len(parser.get('growth_values', 'growth_value_string').strip()) != 0:
+        growthValueString = parser.get(
+            'growth_values', 'growth_value_string').strip()
 
         if 'condition_tuples' in paramDict and 'counts_file_list' in paramDict:
-            expectedComparisons = set(list(zip(*paramDict['condition_tuples']))[0])
-            expectedReplicates = set(list(zip(*paramDict['counts_file_list']))[1])
+            expectedComparisons = set(
+                list(zip(*paramDict['condition_tuples']))[0])
+            expectedReplicates = set(
+                list(zip(*paramDict['counts_file_list']))[1])
 
             expectedTupleList = []
 
             for comp in expectedComparisons:
                 for rep in expectedReplicates:
-                    expectedTupleList.append((comp,rep))
+                    expectedTupleList.append((comp, rep))
         else:
             expectedTupleList = []
-             
+
         enteredTupleList = []
         growthValueTuples = []
-        
+
         for growthValueLine in growthValueString.split('\n'):
             growthValueLine = growthValueLine.strip()
-            
+
             linesplit = growthValueLine.split(':')
-            
+
             if len(linesplit) != 3:
                 warningString += 'Growth value line not understood: ' + growthValueLine + '\n'
                 exitStatus += 1
                 continue
-                
+
             comparison = linesplit[0]
             replicate = linesplit[1]
-            
+
             try:
                 growthVal = float(linesplit[2])
             except ValueError:
@@ -226,21 +243,24 @@ def parseExptConfig(configFile, librariesToSublibrariesDict):
                 exitStatus += 1
                 continue
 
-            curTup = (comparison,replicate)
+            curTup = (comparison, replicate)
             if curTup in expectedTupleList:
                 if curTup not in enteredTupleList:
                     enteredTupleList.append(curTup)
-                    growthValueTuples.append((comparison,replicate,growthVal))
-                    
+                    growthValueTuples.append(
+                        (comparison, replicate, growthVal))
+
                 else:
-                    warningString += ':'.join(curTup) + ' has multiple growth values entered\n'
+                    warningString += ':'.join(curTup) + \
+                        ' has multiple growth values entered\n'
                     exitStatus += 1
             else:
-                warningString += ':'.join(curTup) + ' was not expected given the specified counts file assignments and sgRNA phenotypes\n'
+                warningString += ':'.join(
+                    curTup) + ' was not expected given the specified counts file assignments and sgRNA phenotypes\n'
                 exitStatus += 1
-        
-        #because we enforced no duplicates or unexpected values these should match up unless there were values not entered
-        #require all growth values to be explictly entered if some were
+
+        # because we enforced no duplicates or unexpected values these should match up unless there were values not entered
+        # require all growth values to be explictly entered if some were
         if len(enteredTupleList) != len(expectedTupleList):
             warningString += 'Growth values were not entered for all expected comparisons/replicates. Expected: ' + \
                 ','.join([':'.join(tup) for tup in expectedTupleList]) + '\nEntered: ' + \
@@ -248,24 +268,27 @@ def parseExptConfig(configFile, librariesToSublibrariesDict):
             exitStatus += 1
         else:
             paramDict['growth_value_tuples'] = growthValueTuples
-            
+
     else:
         warningString += 'No growth values--all phenotypes will be reported as log2enrichments\n'
-        
+
         paramDict['growth_value_tuples'] = []
-        
+
         if 'condition_tuples' in paramDict and 'counts_file_list' in paramDict:
-            expectedComparisons = set(list(zip(*paramDict['condition_tuples']))[0])
-            expectedReplicates = set(list(zip(*paramDict['counts_file_list']))[1])
+            expectedComparisons = set(
+                list(zip(*paramDict['condition_tuples']))[0])
+            expectedReplicates = set(
+                list(zip(*paramDict['counts_file_list']))[1])
 
             for comp in expectedComparisons:
                 for rep in expectedReplicates:
-                    paramDict['growth_value_tuples'].append((comp,rep,1))
-    
-    ##Gene Analysis
-    if parser.has_option('gene_analysis','collapse_to_transcripts'):
+                    paramDict['growth_value_tuples'].append((comp, rep, 1))
+
+    # Gene Analysis
+    if parser.has_option('gene_analysis', 'collapse_to_transcripts'):
         try:
-            paramDict['collapse_to_transcripts'] = parser.getboolean('gene_analysis','collapse_to_transcripts')
+            paramDict['collapse_to_transcripts'] = parser.getboolean(
+                'gene_analysis', 'collapse_to_transcripts')
         except ValueError:
             warningString += 'Collapse to transcripts entry not a recognized boolean value\n'
             exitStatus += 1
@@ -273,12 +296,12 @@ def parseExptConfig(configFile, librariesToSublibrariesDict):
         paramDict['collapse_to_transcripts'] = True
         warningString += 'Collapse to transcripts defaulting to True\n'
 
+    # pseudogene parameters
+    if parser.has_option('gene_analysis', 'generate_pseudogene_dist'):
+        paramDict['generate_pseudogene_dist'] = parser.get(
+            'gene_analysis', 'generate_pseudogene_dist').lower()
 
-    #pseudogene parameters
-    if parser.has_option('gene_analysis','generate_pseudogene_dist'):
-        paramDict['generate_pseudogene_dist'] = parser.get('gene_analysis','generate_pseudogene_dist').lower()
-
-        if paramDict['generate_pseudogene_dist'] not in ['auto','manual','off']:
+        if paramDict['generate_pseudogene_dist'] not in ['auto', 'manual', 'off']:
             warningString += 'Generate pseudogene dist entry not a recognized option\n'
             exitStatus += 1
     else:
@@ -286,9 +309,10 @@ def parseExptConfig(configFile, librariesToSublibrariesDict):
         warningString += 'Generate pseudogene dist defaulting to False\n'
 
     if 'generate_pseudogene_dist' in paramDict and paramDict['generate_pseudogene_dist'] == 'manual':
-        if parser.has_option('gene_analysis','pseudogene_size'):
+        if parser.has_option('gene_analysis', 'pseudogene_size'):
             try:
-                paramDict['pseudogene_size'] = parser.getint('gene_analysis','pseudogene_size')
+                paramDict['pseudogene_size'] = parser.getint(
+                    'gene_analysis', 'pseudogene_size')
             except ValueError:
                 warningString += 'Pseudogene size entry not a recognized integer value\n'
                 exitStatus += 1
@@ -296,32 +320,34 @@ def parseExptConfig(configFile, librariesToSublibrariesDict):
             warningString += 'No pseudogene size provided\n'
             exitStatus += 1
 
-        if parser.has_option('gene_analysis','num_pseudogenes'):
+        if parser.has_option('gene_analysis', 'num_pseudogenes'):
             try:
-                paramDict['num_pseudogenes'] = parser.getint('gene_analysis','num_pseudogenes')
+                paramDict['num_pseudogenes'] = parser.getint(
+                    'gene_analysis', 'num_pseudogenes')
             except ValueError:
                 warningString += 'Pseudogene number entry not a recognized integer value\n'
                 exitStatus += 1
         else:
             warningString += 'No pseudogene size provided\n'
 
-    #list possible analyses in param dict as dictionary with keys = analysis and values = analysis-specific params
-    
+    # list possible analyses in param dict as dictionary with keys = analysis and values = analysis-specific params
+
     paramDict['analyses'] = dict()
 
-    #analyze by average of best n
-    if parser.has_option('gene_analysis','calculate_ave'):
+    # analyze by average of best n
+    if parser.has_option('gene_analysis', 'calculate_ave'):
         try:
-            if parser.getboolean('gene_analysis','calculate_ave') == True:
+            if parser.getboolean('gene_analysis', 'calculate_ave') == True:
                 paramDict['analyses']['calculate_ave'] = []
         except ValueError:
             warningString += 'Calculate ave entry not a recognized boolean value\n'
             exitStatus += 1
 
         if 'calculate_ave' in paramDict['analyses']:
-            if parser.has_option('gene_analysis','best_n'):
+            if parser.has_option('gene_analysis', 'best_n'):
                 try:
-                    paramDict['analyses']['calculate_ave'].append(parser.getint('gene_analysis','best_n'))
+                    paramDict['analyses']['calculate_ave'].append(
+                        parser.getint('gene_analysis', 'best_n'))
                 except ValueError:
                     warningString += 'Best_n entry not a recognized integer value\n'
                     exitStatus += 1
@@ -330,31 +356,32 @@ def parseExptConfig(configFile, librariesToSublibrariesDict):
                 exitStatus += 1
     else:
         warningString += 'Best n average analysis not specified, defaulting to False\n'
-    
-    #analyze by Mann-Whitney
-    if parser.has_option('gene_analysis','calculate_mw'):
+
+    # analyze by Mann-Whitney
+    if parser.has_option('gene_analysis', 'calculate_mw'):
         try:
-            if parser.getboolean('gene_analysis','calculate_mw') == True:
+            if parser.getboolean('gene_analysis', 'calculate_mw') == True:
                 paramDict['analyses']['calculate_mw'] = []
         except ValueError:
             warningString += 'Calculate Mann-Whitney entry not a recognized boolean value\n'
             exitStatus += 1
 
-    #analyze by K-S, skipping for now
+    # analyze by K-S, skipping for now
 
-    #analyze by nth best sgRNA
-    if parser.has_option('gene_analysis','calculate_nth'):
+    # analyze by nth best sgRNA
+    if parser.has_option('gene_analysis', 'calculate_nth'):
         try:
-            if parser.getboolean('gene_analysis','calculate_nth') == True:
+            if parser.getboolean('gene_analysis', 'calculate_nth') == True:
                 paramDict['analyses']['calculate_nth'] = []
         except ValueError:
             warningString += 'Calculate best Nth sgRNA entry not a recognized boolean value\n'
             exitStatus += 1
 
         if 'calculate_nth' in paramDict['analyses']:
-            if parser.has_option('gene_analysis','nth'):
+            if parser.has_option('gene_analysis', 'nth'):
                 try:
-                    paramDict['analyses']['calculate_nth'].append(parser.getint('gene_analysis','nth'))
+                    paramDict['analyses']['calculate_nth'].append(
+                        parser.getint('gene_analysis', 'nth'))
                 except ValueError:
                     warningString += 'Nth best sgRNA entry not a recognized integer value\n'
                     exitStatus += 1
@@ -364,29 +391,33 @@ def parseExptConfig(configFile, librariesToSublibrariesDict):
     else:
         warningString += 'Nth best sgRNA analysis not specified, defaulting to False\n'
 
-
     if len(paramDict['analyses']) == 0:
-        warningString += 'No analyses selected to compute gene scores\n' #should this raise exitStatus?
+        # should this raise exitStatus?
+        warningString += 'No analyses selected to compute gene scores\n'
 
     return paramDict, exitStatus, warningString
-    
-#Parse the library configuration file to get the available libraries, sublibraries, and corresponding library table files
+
+# Parse the library configuration file to get the available libraries, sublibraries, and corresponding library table files
+
+
 def parseLibraryConfig(libConfigFile):
     parser = ConfigParser()
     result = parser.read(libConfigFile)
     if len(result) == 0:
         raise ValueError('Library config file not found')
-    
+
     librariesToSublibraries = dict()
     librariesToTables = dict()
     for library in parser.sections():
         tableFile = parser.get(library, 'filename').strip()
         librariesToTables[library.lower()] = tableFile
 
-        sublibraryList = parser.get(library, 'sublibraries').strip().split('\n')
-        librariesToSublibraries[library.lower()] = [sub.strip().lower() for sub in sublibraryList]
+        sublibraryList = parser.get(
+            library, 'sublibraries').strip().split('\n')
+        librariesToSublibraries[library.lower()] = [sub.strip().lower()
+                                                    for sub in sublibraryList]
 
     if len(librariesToTables) == 0:
         raise ValueError('Library config file empty')
-    
+
     return librariesToSublibraries, librariesToTables

--- a/fastqgz_to_counts.py
+++ b/fastqgz_to_counts.py
@@ -171,7 +171,8 @@ def printNow(printInput):
 
 
 ### Global variables ###
-acceptedFileTypes = [('*.fastq.gz', 'fqgz'),
+acceptedFileTypes = [('*.fq.gz', 'fqgz'),
+                     ('*.fastq.gz', 'fqgz'),
                      ('*.fastq', 'fq'),
                      ('*.fq', 'fq'),
                      ('*.fa', 'fa'),

--- a/fastqgz_to_counts.py
+++ b/fastqgz_to_counts.py
@@ -10,222 +10,240 @@ import argparse
 
 ### Sequence File to Trimmed Fasta Functions ###
 
+
 def parallelSeqFileToCountsParallel(fastqGzFileNameList, fastaFileNameList, countFileNameList, processPool, libraryFasta, startIndex=None, stopIndex=None, test=False):
 
-	if len(fastqGzFileNameList) != len(fastaFileNameList):
-		raise ValueError('In and out file lists must be the same length')
+    if len(fastqGzFileNameList) != len(fastaFileNameList):
+        raise ValueError('In and out file lists must be the same length')
 
-	arglist = zip(fastqGzFileNameList, fastaFileNameList, countFileNameList, [libraryFasta]*len(fastaFileNameList), 
-                  [startIndex]*len(fastaFileNameList),[stopIndex]*len(fastaFileNameList), [test]*len(fastaFileNameList))
-	
-	readsPerFile = processPool.map(seqFileToCountsWrapper, arglist)
+    arglist = zip(fastqGzFileNameList, fastaFileNameList, countFileNameList, [libraryFasta]*len(fastaFileNameList),
+                  [startIndex]*len(fastaFileNameList), [stopIndex]*len(fastaFileNameList), [test]*len(fastaFileNameList))
 
-	return zip(countFileNameList,readsPerFile)
+    readsPerFile = processPool.map(seqFileToCountsWrapper, arglist)
+
+    return zip(countFileNameList, readsPerFile)
 
 
 def seqFileToCountsWrapper(arg):
-	return seqFileToCounts(*arg)
+    return seqFileToCounts(*arg)
 
 
 def seqFileToCounts(infileName, fastaFileName, countFileName, libraryFasta, startIndex=None, stopIndex=None, test=False):
-	printNow('Processing %s' % infileName)
-	
-	fileType = None
+    printNow('Processing %s' % infileName)
 
-	for fileTup in acceptedFileTypes:
-		if fnmatch.fnmatch(infileName,fileTup[0]):
-			fileType = fileTup[1]
-			break
-		
-	if fileType == 'fqgz':
-		linesPerRead = 4
-		infile = gzip.open(infileName,mode='rt')
-	elif fileType == 'fq':
-		linesPerRead = 4
-		infile = open(infileName)
-	elif fileType == 'fa':
-		linesPerRead = 2
-		infile = open(infileName)
-	else:
-		raise ValueError('Sequencing file type not recognized!')
-		
-	
-	seqToIdDict, idsToReadcountDict, expectedReadLength = parseLibraryFasta(libraryFasta)
-	
-	curRead = 0
-	numAligning = 0
+    fileType = None
 
-	with open(fastaFileName,'w') as unalignedFile:
-		for i, fastqLine in enumerate(infile):
-			if i % linesPerRead != 1:
-				continue
+    for fileTup in acceptedFileTypes:
+        if fnmatch.fnmatch(infileName, fileTup[0]):
+            fileType = fileTup[1]
+            break
 
-			else:
-				seq = fastqLine.strip()[startIndex:stopIndex]
-			
-				if i == 1 and len(seq) != expectedReadLength:
-					raise ValueError('Trimmed read length does not match expected reference read length')
-			
-				if seq in seqToIdDict:
-					for seqId in seqToIdDict[seq]:
-						idsToReadcountDict[seqId] += 1
-						
-					numAligning += 1
-			
-				else:
-					unalignedFile.write('>%d\n%s\n' % (i, seq))
+    if fileType == 'fqgz':
+        linesPerRead = 4
+        infile = gzip.open(infileName, mode='rt')
+    elif fileType == 'fq':
+        linesPerRead = 4
+        infile = open(infileName)
+    elif fileType == 'fa':
+        linesPerRead = 2
+        infile = open(infileName)
+    else:
+        raise ValueError('Sequencing file type not recognized!')
 
-				curRead += 1
-		
-				#allow test runs using only the first N reads from the fastq file
-				if test and curRead >= testLines:
-					break
+    seqToIdDict, idsToReadcountDict, expectedReadLength = parseLibraryFasta(
+        libraryFasta)
 
-	with open(countFileName,'w') as countFile:
-		for countTup in (sorted(zip(idsToReadcountDict.keys(), idsToReadcountDict.values()))):
-			countFile.write('%s\t%d\n' % countTup)
+    curRead = 0
+    numAligning = 0
 
-	printNow('Done processing %s' % infileName)
-	
-	return curRead, numAligning, numAligning * 100.0 / curRead
+    with open(fastaFileName, 'w') as unalignedFile:
+        for i, fastqLine in enumerate(infile):
+            if i % linesPerRead != 1:
+                continue
+
+            else:
+                seq = fastqLine.strip()[startIndex:stopIndex]
+
+                if i == 1 and len(seq) != expectedReadLength:
+                    raise ValueError(
+                        'Trimmed read length does not match expected reference read length')
+
+                if seq in seqToIdDict:
+                    for seqId in seqToIdDict[seq]:
+                        idsToReadcountDict[seqId] += 1
+
+                    numAligning += 1
+
+                else:
+                    unalignedFile.write('>%d\n%s\n' % (i, seq))
+
+                curRead += 1
+
+                # allow test runs using only the first N reads from the fastq file
+                if test and curRead >= testLines:
+                    break
+
+    with open(countFileName, 'w') as countFile:
+        for countTup in (sorted(zip(idsToReadcountDict.keys(), idsToReadcountDict.values()))):
+            countFile.write('%s\t%d\n' % countTup)
+
+    printNow('Done processing %s' % infileName)
+
+    return curRead, numAligning, numAligning * 100.0 / curRead
 
 
 ### Map File to Counts File Functions ###
 
 def parseLibraryFasta(libraryFasta):
-	seqToIds, idsToReadcounts, readLengths = dict(), dict(), []
+    seqToIds, idsToReadcounts, readLengths = dict(), dict(), []
 
-	curSeqId = ''
-	curSeq = ''
-	
-	with open(libraryFasta) as infile:
-		for line in infile:
-			if line[0] == '>':
-				if curSeqId != '' and curSeq != '':
-					if curSeq not in seqToIds:
-						seqToIds[curSeq] = []
-					seqToIds[curSeq].append(curSeqId)
+    curSeqId = ''
+    curSeq = ''
 
-					idsToReadcounts[curSeqId] = 0
+    with open(libraryFasta) as infile:
+        for line in infile:
+            if line[0] == '>':
+                if curSeqId != '' and curSeq != '':
+                    if curSeq not in seqToIds:
+                        seqToIds[curSeq] = []
+                    seqToIds[curSeq].append(curSeqId)
 
-					readLengths.append(len(curSeq))
-					
-				curSeqId = line.strip()[1:]
-				curSeq = ''
-				
-			else:
-				curSeq += line.strip().upper()
+                    idsToReadcounts[curSeqId] = 0
 
-        #at the end, add the final item that was not covered in the loop           
-        if curSeqId != '' and curSeq != '':
-            if curSeq not in seqToIds:
-                seqToIds[curSeq] = []
-            seqToIds[curSeq].append(curSeqId)
+                    readLengths.append(len(curSeq))
 
-            idsToReadcounts[curSeqId] = 0
+                curSeqId = line.strip()[1:]
+                curSeq = ''
 
-            readLengths.append(len(curSeq))
-            
-	if len(seqToIds) == 0 or len(idsToReadcounts) == 0 or readLengths[0] == 0:
-		raise ValueError('library fasta could not be parsed or contains no sequences')
-	elif max(readLengths) != min(readLengths):
-		print(min(readLengths), max(readLengths))
-		raise ValueError('library reference sequences are of inconsistent lengths')
+            else:
+                curSeq += line.strip().upper()
 
-	return seqToIds, idsToReadcounts, readLengths[0]
+    # at the end, add the final item that was not covered in the loop
+    if curSeqId != '' and curSeq != '':
+        if curSeq not in seqToIds:
+            seqToIds[curSeq] = []
+        seqToIds[curSeq].append(curSeqId)
+
+        idsToReadcounts[curSeqId] = 0
+
+        readLengths.append(len(curSeq))
+
+    if len(seqToIds) == 0 or len(idsToReadcounts) == 0 or readLengths[0] == 0:
+        raise ValueError(
+            'library fasta could not be parsed or contains no sequences')
+    elif max(readLengths) != min(readLengths):
+        print(min(readLengths), max(readLengths))
+        raise ValueError(
+            'library reference sequences are of inconsistent lengths')
+
+    return seqToIds, idsToReadcounts, readLengths[0]
 
 
 ### Utility Functions ###
 def parseSeqFileNames(fileNameList):
-	infileList = []
-	outfileBaseList = []
+    infileList = []
+    outfileBaseList = []
 
-	for inputFileName in fileNameList:					#iterate through entered filenames for sequence files
-		for filename in glob.glob(inputFileName): 		#generate all possible files given wildcards
-			for fileType in list(zip(*acceptedFileTypes))[0]:	#iterate through allowed filetypes
-				if fnmatch.fnmatch(filename,fileType):
-					infileList.append(filename)
-					outfileBaseList.append(os.path.split(filename)[-1].split('.')[0])
+    for inputFileName in fileNameList:  # iterate through entered filenames for sequence files
+        # generate all possible files given wildcards
+        for filename in glob.glob(inputFileName):
+            # iterate through allowed filetypes
+            for fileType in list(zip(*acceptedFileTypes))[0]:
+                if fnmatch.fnmatch(filename, fileType):
+                    infileList.append(filename)
+                    outfileBaseList.append(
+                        os.path.split(filename)[-1].split('.')[0])
 
-	return infileList, outfileBaseList
+    return infileList, outfileBaseList
+
 
 def makeDirectory(path):
-	try:
-		os.makedirs(path)
-	except OSError:
-		#printNow(path + ' already exists')
-		pass
+    try:
+        os.makedirs(path)
+    except OSError:
+        #printNow(path + ' already exists')
+        pass
+
 
 def printNow(printInput):
-	print(printInput)
-	sys.stdout.flush()
+    print(printInput)
+    sys.stdout.flush()
+
 
 ### Global variables ###
-acceptedFileTypes = [('*.fastq.gz','fqgz'),
-					('*.fastq', 'fq'),
-					('*.fq', 'fq'),
-					('*.fa', 'fa'),
-					('*.fasta', 'fa'),
-					('*.fna', 'fa')]
+acceptedFileTypes = [('*.fastq.gz', 'fqgz'),
+                     ('*.fastq', 'fq'),
+                     ('*.fq', 'fq'),
+                     ('*.fa', 'fa'),
+                     ('*.fasta', 'fa'),
+                     ('*.fna', 'fa')]
 
 
 testLines = 10000
 
 
 if __name__ == '__main__':
-	parser = argparse.ArgumentParser(description='Process raw sequencing data from screens to counts files in parallel')
-	parser.add_argument('Library_Fasta', help='Fasta file of expected library reads.')
-	parser.add_argument('Out_File_Path', help='Directory where output files should be written.')
-	parser.add_argument('Seq_File_Names', nargs='+', help='Name(s) of sequencing file(s). Unix wildcards can be used to select multiple files at once. The script will search for all *.fastq.gz, *.fastq, and *.fa(/fasta/fna) files with the given wildcard name.')
-			
-	parser.add_argument('-p','--processors', type=int, default = 1)
-	parser.add_argument('--trim_start', type=int)
-	parser.add_argument('--trim_end', type=int)
-	parser.add_argument('--test', action='store_true', default=False, help='Run the entire script on only the first %d reads of each file. Be sure to delete or move all test files before re-running script as they will not be overwritten.' % testLines)
+    parser = argparse.ArgumentParser(
+        description='Process raw sequencing data from screens to counts files in parallel')
+    parser.add_argument(
+        'Library_Fasta', help='Fasta file of expected library reads.')
+    parser.add_argument(
+        'Out_File_Path', help='Directory where output files should be written.')
+    parser.add_argument('Seq_File_Names', nargs='+', help='Name(s) of sequencing file(s). Unix wildcards can be used to select multiple files at once. The script will search for all *.fastq.gz, *.fastq, and *.fa(/fasta/fna) files with the given wildcard name.')
 
-	args = parser.parse_args()
-	#printNow(args)
+    parser.add_argument('-p', '--processors', type=int, default=1)
+    parser.add_argument('--trim_start', type=int)
+    parser.add_argument('--trim_end', type=int)
+    parser.add_argument('--test', action='store_true', default=False,
+                        help='Run the entire script on only the first %d reads of each file. Be sure to delete or move all test files before re-running script as they will not be overwritten.' % testLines)
 
-	###catch input mistakes###
-	numProcessors = max(args.processors, 1)
+    args = parser.parse_args()
+    # printNow(args)
 
-	infileList, outfileBaseList = parseSeqFileNames(args.Seq_File_Names)
-	if len(infileList) == 0:
-		sys.exit('Input error: no sequencing files found')
-			
-	try:
-		seqToIdDict, idsToReadcountDict, expectedReadLength = parseLibraryFasta(args.Library_Fasta)
-			
-		printNow('Library file loaded successfully:\n\t%.2E elements (%.2E unique sequences)\t%dbp reads expected' \
-				% (len(idsToReadcountDict), len(seqToIdDict), expectedReadLength))
-		
-	except IOError:
-		sys.exit('Input error: library fasta file not found')
-		
-	except ValueError as err:
-		sys.exit('Input error: ' + err.args[0])
-	
-	
-	trimmedFastaPath = os.path.join(args.Out_File_Path,'unaligned_reads')
-	makeDirectory(trimmedFastaPath)
-	countFilePath = os.path.join(args.Out_File_Path,'count_files')
-	makeDirectory(countFilePath)
+    ###catch input mistakes###
+    numProcessors = max(args.processors, 1)
 
-	fastaFileNameList = [outfileName + '_unaligned.fa' for outfileName in outfileBaseList] 
-	fastaFilePathList = [os.path.join(trimmedFastaPath, fastaFileName) for fastaFileName in fastaFileNameList]
-	countFilePathList = [os.path.join(countFilePath,outfileName + '_' + os.path.split(args.Library_Fasta)[-1] + '.counts') for outfileName in outfileBaseList]
+    infileList, outfileBaseList = parseSeqFileNames(args.Seq_File_Names)
+    if len(infileList) == 0:
+        sys.exit('Input error: no sequencing files found')
 
-	pool = multiprocessing.Pool(min(len(infileList),numProcessors))
+    try:
+        seqToIdDict, idsToReadcountDict, expectedReadLength = parseLibraryFasta(
+            args.Library_Fasta)
 
-	try:
-		resultList = parallelSeqFileToCountsParallel(infileList, fastaFilePathList, countFilePathList, pool, args.Library_Fasta, args.trim_start, args.trim_end, args.test)
-	except ValueError as err:
-		sys.exit('Error while processing sequencing files: ' + ' '.join(err.args))
-		
-	for filename, result in resultList:
-		print(filename + ':\n\t%.2E reads\t%.2E aligning (%.2f%%)' % result)
-	
-	pool.close()
-	pool.join()
+        printNow('Library file loaded successfully:\n\t%.2E elements (%.2E unique sequences)\t%dbp reads expected'
+                 % (len(idsToReadcountDict), len(seqToIdDict), expectedReadLength))
 
-	printNow('Done processing all sequencing files')
+    except IOError:
+        sys.exit('Input error: library fasta file not found')
+
+    except ValueError as err:
+        sys.exit('Input error: ' + err.args[0])
+
+    trimmedFastaPath = os.path.join(args.Out_File_Path, 'unaligned_reads')
+    makeDirectory(trimmedFastaPath)
+    countFilePath = os.path.join(args.Out_File_Path, 'count_files')
+    makeDirectory(countFilePath)
+
+    fastaFileNameList = [outfileName +
+                         '_unaligned.fa' for outfileName in outfileBaseList]
+    fastaFilePathList = [os.path.join(
+        trimmedFastaPath, fastaFileName) for fastaFileName in fastaFileNameList]
+    countFilePathList = [os.path.join(countFilePath, outfileName + '_' + os.path.split(
+        args.Library_Fasta)[-1] + '.counts') for outfileName in outfileBaseList]
+
+    pool = multiprocessing.Pool(min(len(infileList), numProcessors))
+
+    try:
+        resultList = parallelSeqFileToCountsParallel(
+            infileList, fastaFilePathList, countFilePathList, pool, args.Library_Fasta, args.trim_start, args.trim_end, args.test)
+    except ValueError as err:
+        sys.exit('Error while processing sequencing files: ' + ' '.join(err.args))
+
+    for filename, result in resultList:
+        print(filename + ':\n\t%.2E reads\t%.2E aligning (%.2f%%)' % result)
+
+    pool.close()
+    pool.join()
+
+    printNow('Done processing all sequencing files')

--- a/process_experiments.py
+++ b/process_experiments.py
@@ -16,39 +16,47 @@ import screen_analysis
 
 defaultLibConfigName = 'library_config.txt'
 
-#a screen processing pipeline that requires just a config file and a directory of supported libraries
-#error checking in config parser is fairly robust, so not checking for input errors here
+# a screen processing pipeline that requires just a config file and a directory of supported libraries
+# error checking in config parser is fairly robust, so not checking for input errors here
+
+
 def processExperimentsFromConfig(configFile, libraryDirectory, generatePlots='png'):
-    #load in the supported libraries and sublibraries
+    # load in the supported libraries and sublibraries
     try:
-        librariesToSublibraries, librariesToTables = parseLibraryConfig(os.path.join(libraryDirectory, defaultLibConfigName))
+        librariesToSublibraries, librariesToTables = parseLibraryConfig(
+            os.path.join(libraryDirectory, defaultLibConfigName))
     except ValueError as err:
         print(' '.join(err.args))
         return
 
-    exptParameters, parseStatus, parseString = parseExptConfig(configFile, librariesToSublibraries)
+    exptParameters, parseStatus, parseString = parseExptConfig(
+        configFile, librariesToSublibraries)
 
     printNow(parseString)
 
-    if parseStatus > 0: #Critical errors in parsing
+    if parseStatus > 0:  # Critical errors in parsing
         print('Exiting due to experiment config file errors\n')
         return
 
     makeDirectory(exptParameters['output_folder'])
-    outbase = os.path.join(exptParameters['output_folder'],exptParameters['experiment_name'])
-    
-    if generatePlots != 'off':
-        plotDirectory = os.path.join(exptParameters['output_folder'],exptParameters['experiment_name'] + '_plots')
-        makeDirectory(plotDirectory)
-    
-        screen_analysis.changeDisplayFigureSettings(newDirectory=plotDirectory, newImageExtension = generatePlots, newPlotWithPylab = False)
-    
+    outbase = os.path.join(
+        exptParameters['output_folder'], exptParameters['experiment_name'])
 
-    #load in library table and filter to requested sublibraries
+    if generatePlots != 'off':
+        plotDirectory = os.path.join(
+            exptParameters['output_folder'], exptParameters['experiment_name'] + '_plots')
+        makeDirectory(plotDirectory)
+
+        screen_analysis.changeDisplayFigureSettings(
+            newDirectory=plotDirectory, newImageExtension=generatePlots, newPlotWithPylab=False)
+
+    # load in library table and filter to requested sublibraries
     printNow('Accessing library information')
 
-    libraryTable = pd.read_csv(os.path.join(libraryDirectory, librariesToTables[exptParameters['library']]), sep = '\t', header=0, index_col=0).sort_index()
-    sublibColumn = libraryTable.apply(lambda row: row['sublibrary'].lower() in exptParameters['sublibraries'], axis=1)
+    libraryTable = pd.read_csv(os.path.join(
+        libraryDirectory, librariesToTables[exptParameters['library']]), sep='\t', header=0, index_col=0).sort_index()
+    sublibColumn = libraryTable.apply(
+        lambda row: row['sublibrary'].lower() in exptParameters['sublibraries'], axis=1)
 
     if sum(sublibColumn) == 0:
         print('After limiting analysis to specified sublibraries, no elements are left')
@@ -56,100 +64,117 @@ def processExperimentsFromConfig(configFile, libraryDirectory, generatePlots='pn
 
     libraryTable[sublibColumn].to_csv(outbase + '_librarytable.txt', sep='\t')
 
-    #load in counts, create table of total counts in each and each file as a column
+    # load in counts, create table of total counts in each and each file as a column
     printNow('Loading counts data')
 
     columnDict = dict()
     for tup in sorted(exptParameters['counts_file_list']):
         if tup in columnDict:
             print('Asserting that tuples of condition, replicate, and count file should be unique; are the cases where this should not be enforced?')
-            raise Exception('condition, replicate, and count file combination already assigned')
-        
-        countSeries = readCountsFile(tup[2]).reset_index().drop_duplicates('id').set_index('id') #for now also dropping duplicate ids in counts for overlapping linc sublibraries
-        countSeries = libraryTable[sublibColumn].align(countSeries, axis=0, join='left', fill_value=0)[1] #expand series to fill 0 for every missing entry
+            raise Exception(
+                'condition, replicate, and count file combination already assigned')
 
-        columnDict[tup] = countSeries['counts'] #[sublibColumn] #then shrink series to only desired sublibraries
+        # for now also dropping duplicate ids in counts for overlapping linc sublibraries
+        countSeries = readCountsFile(tup[2]).reset_index(
+        ).drop_duplicates('id').set_index('id')
+        countSeries = libraryTable[sublibColumn].align(countSeries, axis=0, join='left', fill_value=0)[
+            1]  # expand series to fill 0 for every missing entry
+
+        # [sublibColumn] #then shrink series to only desired sublibraries
+        columnDict[tup] = countSeries['counts']
 
     # print columnDict
-    countsTable = pd.DataFrame(columnDict)#, index=libraryTable[sublibColumn].index)
+    # , index=libraryTable[sublibColumn].index)
+    countsTable = pd.DataFrame(columnDict)
     countsTable.to_csv(outbase + '_rawcountstable.txt', sep='\t')
-    countsTable.sum().to_csv(outbase + '_rawcountstable_summary.txt', sep='\t',header=False)
+    countsTable.sum().to_csv(outbase + '_rawcountstable_summary.txt', sep='\t', header=False)
 
-    #merge counts for same conditions/replicates, and create summary table
-    #save scatter plot before each merger, and histogram of counts post mergers
+    # merge counts for same conditions/replicates, and create summary table
+    # save scatter plot before each merger, and histogram of counts post mergers
     printNow('Merging experiment counts split across lanes/indexes')
-    
-    exptGroups = countsTable.groupby(level=[0,1], axis=1)
+
+    exptGroups = countsTable.groupby(level=[0, 1], axis=1)
     mergedCountsTable = exptGroups.aggregate(np.sum)
     mergedCountsTable.to_csv(outbase + '_mergedcountstable.txt', sep='\t')
-    mergedCountsTable.sum().to_csv(outbase + '_mergedcountstable_summary.txt', sep='\t',header=False)
-    
+    mergedCountsTable.sum().to_csv(
+        outbase + '_mergedcountstable_summary.txt', sep='\t', header=False)
+
     if generatePlots != 'off' and max(exptGroups.count().iloc[0]) > 1:
         printNow('-generating scatter plots of counts pre-merger')
-    
+
         tempDataDict = {'library': libraryTable[sublibColumn],
                         'premerged counts': countsTable,
-                       'counts': mergedCountsTable}
+                        'counts': mergedCountsTable}
 
         for (phenotype, replicate), countsCols in exptGroups:
             if len(countsCols.columns) == 1:
                 continue
-            
+
             else:
-                screen_analysis.premergedCountsScatterMatrix(tempDataDict, phenotype, replicate)
+                screen_analysis.premergedCountsScatterMatrix(
+                    tempDataDict, phenotype, replicate)
 
     if generatePlots != 'off':
         printNow('-generating sgRNA read count histograms')
-    
+
         tempDataDict = {'library': libraryTable[sublibColumn],
                         'counts': mergedCountsTable}
-                    
+
         for (phenotype, replicate), countsCol in mergedCountsTable.iteritems():
             screen_analysis.countsHistogram(tempDataDict, phenotype, replicate)
-    
-    #create pairs of columns for each comparison, filter to na, then generate sgRNA phenotype score
+
+    # create pairs of columns for each comparison, filter to na, then generate sgRNA phenotype score
     printNow('Computing sgRNA phenotype scores')
 
-    growthValueDict = {(tup[0],tup[1]):tup[2] for tup in exptParameters['growth_value_tuples']}
-    phenotypeList = list(set(list(zip(*exptParameters['condition_tuples']))[0]))
-    replicateList = sorted(list(set(list(zip(*exptParameters['counts_file_list']))[1])))
+    growthValueDict = {(tup[0], tup[1]): tup[2]
+                       for tup in exptParameters['growth_value_tuples']}
+    phenotypeList = list(
+        set(list(zip(*exptParameters['condition_tuples']))[0]))
+    replicateList = sorted(
+        list(set(list(zip(*exptParameters['counts_file_list']))[1])))
 
     phenotypeScoreDict = dict()
     for (phenotype, condition1, condition2) in exptParameters['condition_tuples']:
         for replicate in replicateList:
-            column1 = mergedCountsTable[(condition1,replicate)]
-            column2 = mergedCountsTable[(condition2,replicate)]
-            filtCols = filterLowCounts(pd.concat((column1, column2), axis = 1, sort=True), exptParameters['filter_type'], exptParameters['minimum_reads'])
-            
+            column1 = mergedCountsTable[(condition1, replicate)]
+            column2 = mergedCountsTable[(condition2, replicate)]
+            filtCols = filterLowCounts(pd.concat((column1, column2), axis=1, sort=True),
+                                       exptParameters['filter_type'], exptParameters['minimum_reads'])
 
-            score = computePhenotypeScore(filtCols[(condition1, replicate)], filtCols[(condition2,replicate)], 
-                                            libraryTable[sublibColumn], growthValueDict[(phenotype,replicate)], 
-                                            exptParameters['pseudocount_behavior'], exptParameters['pseudocount'])
+            score = computePhenotypeScore(filtCols[(condition1, replicate)], filtCols[(condition2, replicate)],
+                                          libraryTable[sublibColumn], growthValueDict[(
+                                              phenotype, replicate)],
+                                          exptParameters['pseudocount_behavior'], exptParameters['pseudocount'])
 
-            phenotypeScoreDict[(phenotype,replicate)] = score
-    
-    if generatePlots  != 'off':
+            phenotypeScoreDict[(phenotype, replicate)] = score
+
+    if generatePlots != 'off':
         tempDataDict = {'library': libraryTable[sublibColumn],
                         'counts': mergedCountsTable,
                         'phenotypes': pd.DataFrame(phenotypeScoreDict)}
-                        
+
         printNow('-generating phenotype histograms and scatter plots')
-        
+
         for (phenotype, condition1, condition2) in exptParameters['condition_tuples']:
             for replicate in replicateList:
-                screen_analysis.countsScatter(tempDataDict, condition1, replicate, condition2, replicate, 
-                    colorByPhenotype_condition = phenotype, colorByPhenotype_replicate = replicate)
-                    
-                screen_analysis.phenotypeHistogram(tempDataDict, phenotype, replicate)
-                screen_analysis.sgRNAsPassingFilterHist(tempDataDict, phenotype, replicate)
-    
-    #scatterplot sgRNAs for all replicates, then average together and add columns to phenotype score table
+                screen_analysis.countsScatter(tempDataDict, condition1, replicate, condition2, replicate,
+                                              colorByPhenotype_condition=phenotype, colorByPhenotype_replicate=replicate)
+
+                screen_analysis.phenotypeHistogram(
+                    tempDataDict, phenotype, replicate)
+                screen_analysis.sgRNAsPassingFilterHist(
+                    tempDataDict, phenotype, replicate)
+
+    # scatterplot sgRNAs for all replicates, then average together and add columns to phenotype score table
     if len(replicateList) > 1:
         printNow('Averaging replicates')
 
         for phenotype in phenotypeList:
-            repCols = pd.DataFrame({(phen,rep):col for (phen,rep), col in phenotypeScoreDict.items() if phen == phenotype})
-            phenotypeScoreDict[(phenotype,'ave_' + '_'.join(replicateList))] = repCols.mean(axis=1,skipna=False) #average nan and real to nan; otherwise this could lead to data points with just one rep informing results
+            repCols = pd.DataFrame({(phen, rep): col for (
+                phen, rep), col in phenotypeScoreDict.items() if phen == phenotype})
+            # average nan and real to nan; otherwise this could lead to data points with just one rep informing results
+            phenotypeScoreDict[(phenotype, 'ave_' + '_'.join(replicateList))
+                               ] = repCols.mean(axis=1, skipna=False)
 
     phenotypeTable = pd.DataFrame(phenotypeScoreDict).sort_index(axis=1)
     phenotypeTable.to_csv(outbase + '_phenotypetable.txt', sep='\t')
@@ -157,24 +182,26 @@ def processExperimentsFromConfig(configFile, libraryDirectory, generatePlots='pn
     if len(replicateList) > 1 and generatePlots != 'off':
         tempDataDict = {'library': libraryTable[sublibColumn],
                         'phenotypes': phenotypeTable}
-                    
+
         printNow('-generating replicate phenotype histograms and scatter plots')
-    
+
         for phenotype, phengroup in phenotypeTable.groupby(level=0, axis=1):
             for i, ((p, rep1), col1) in enumerate(phengroup.iteritems()):
                 if rep1[:4] == 'ave_':
-                    screen_analysis.phenotypeHistogram(tempDataDict, phenotype, rep1)
-            
-                for j, ((p, rep2), col2) in enumerate(phengroup.iteritems()):
-                    if rep2[:4] == 'ave_' or j<=i:
-                        continue
-                    
-                    else:
-                        screen_analysis.phenotypeScatter(tempDataDict, phenotype, rep1, phenotype, rep2)                    
-                
+                    screen_analysis.phenotypeHistogram(
+                        tempDataDict, phenotype, rep1)
 
-    #generate pseudogenes
-    negTable = phenotypeTable.loc[libraryTable[sublibColumn].loc[:,'gene'] == 'negative_control',:]
+                for j, ((p, rep2), col2) in enumerate(phengroup.iteritems()):
+                    if rep2[:4] == 'ave_' or j <= i:
+                        continue
+
+                    else:
+                        screen_analysis.phenotypeScatter(
+                            tempDataDict, phenotype, rep1, phenotype, rep2)
+
+    # generate pseudogenes
+    negTable = phenotypeTable.loc[libraryTable[sublibColumn].loc[:,
+                                                                 'gene'] == 'negative_control', :]
 
     if exptParameters['generate_pseudogene_dist'] != 'off' and len(exptParameters['analyses']) > 0:
         print('Generating a pseudogene distribution from negative controls')
@@ -187,107 +214,131 @@ def processExperimentsFromConfig(configFile, libraryDirectory, generatePlots='pn
 
         if exptParameters['generate_pseudogene_dist'].lower() == 'manual':
             for pseudogene in range(exptParameters['num_pseudogenes']):
-                randIndices = np.random.randint(0, len(negTable), exptParameters['pseudogene_size'])
-                pseudoTable = negValues[randIndices,:]
-                pseudoIndex = ['pseudo_%d_%d' % (pseudogene,i) for i in range(exptParameters['pseudogene_size'])]
-                pseudoSeqs = ['seq_%d_%d' % (pseudogene,i) for i in range(exptParameters['pseudogene_size'])] #so pseudogenes aren't treated as duplicates
-                pseudoTableList.append(pd.DataFrame(pseudoTable,index=pseudoIndex,columns=negColumns))
-                pseudoLib = pd.DataFrame({'gene':['pseudo_%d'%pseudogene]*exptParameters['pseudogene_size'],
-                    'transcripts':['na']*exptParameters['pseudogene_size'],
-                    'sequence':pseudoSeqs},index=pseudoIndex)
+                randIndices = np.random.randint(
+                    0, len(negTable), exptParameters['pseudogene_size'])
+                pseudoTable = negValues[randIndices, :]
+                pseudoIndex = ['pseudo_%d_%d' % (pseudogene, i) for i in range(
+                    exptParameters['pseudogene_size'])]
+                pseudoSeqs = ['seq_%d_%d' % (pseudogene, i) for i in range(
+                    exptParameters['pseudogene_size'])]  # so pseudogenes aren't treated as duplicates
+                pseudoTableList.append(pd.DataFrame(
+                    pseudoTable, index=pseudoIndex, columns=negColumns))
+                pseudoLib = pd.DataFrame({'gene': ['pseudo_%d' % pseudogene]*exptParameters['pseudogene_size'],
+                                          'transcripts': ['na']*exptParameters['pseudogene_size'],
+                                          'sequence': pseudoSeqs}, index=pseudoIndex)
                 pseudoLibTables.append(pseudoLib)
 
         elif exptParameters['generate_pseudogene_dist'].lower() == 'auto':
-            for pseudogene, (gene, group) in enumerate(libraryTable[sublibColumn].drop_duplicates(['gene','sequence']).groupby('gene')):
+            for pseudogene, (gene, group) in enumerate(libraryTable[sublibColumn].drop_duplicates(['gene', 'sequence']).groupby('gene')):
                 if gene == 'negative_control':
-                    continue 
+                    continue
                 for transcript, (transcriptName, transcriptGroup) in enumerate(group.groupby('transcripts')):
-                    randIndices = np.random.randint(0, len(negTable), len(transcriptGroup))
-                    pseudoTable = negValues[randIndices,:]
-                    pseudoIndex = ['pseudo_%d_%d_%d' % (pseudogene, transcript, i) for i in range(len(transcriptGroup))]
-                    pseudoSeqs = ['seq_%d_%d_%d' % (pseudogene, transcript, i) for i in range(len(transcriptGroup))]
-                    pseudoTableList.append(pd.DataFrame(pseudoTable,index=pseudoIndex,columns=negColumns))
-                    pseudoLib = pd.DataFrame({'gene':['pseudo_%d'%pseudogene]*len(transcriptGroup),
-                        'transcripts':['pseudo_transcript_%d'%transcript]*len(transcriptGroup),
-                        'sequence':pseudoSeqs},index=pseudoIndex)
+                    randIndices = np.random.randint(
+                        0, len(negTable), len(transcriptGroup))
+                    pseudoTable = negValues[randIndices, :]
+                    pseudoIndex = ['pseudo_%d_%d_%d' % (
+                        pseudogene, transcript, i) for i in range(len(transcriptGroup))]
+                    pseudoSeqs = ['seq_%d_%d_%d' % (
+                        pseudogene, transcript, i) for i in range(len(transcriptGroup))]
+                    pseudoTableList.append(pd.DataFrame(
+                        pseudoTable, index=pseudoIndex, columns=negColumns))
+                    pseudoLib = pd.DataFrame({'gene': ['pseudo_%d' % pseudogene]*len(transcriptGroup),
+                                              'transcripts': ['pseudo_transcript_%d' % transcript]*len(transcriptGroup),
+                                              'sequence': pseudoSeqs}, index=pseudoIndex)
                     pseudoLibTables.append(pseudoLib)
 
         else:
             print('generate_pseudogene_dist parameter not recognized, defaulting to off')
 
-        phenotypeTable = phenotypeTable.append(pd.concat(pseudoTableList,sort=True))
-        libraryTableGeneAnalysis = libraryTable[sublibColumn].append(pd.concat(pseudoLibTables,sort=True))
+        phenotypeTable = phenotypeTable.append(
+            pd.concat(pseudoTableList, sort=True))
+        libraryTableGeneAnalysis = libraryTable[sublibColumn].append(
+            pd.concat(pseudoLibTables, sort=True))
     else:
         libraryTableGeneAnalysis = libraryTable[sublibColumn]
 
-    #compute gene scores for replicates, averaged reps, and pseudogenes
+    # compute gene scores for replicates, averaged reps, and pseudogenes
     if len(exptParameters['analyses']) > 0:
         print('Computing gene scores')
         sys.stdout.flush()
 
-        phenotypeTable_deduplicated = phenotypeTable.loc[libraryTableGeneAnalysis.drop_duplicates(['gene','sequence']).index]
+        phenotypeTable_deduplicated = phenotypeTable.loc[libraryTableGeneAnalysis.drop_duplicates([
+                                                                                                  'gene', 'sequence']).index]
         if exptParameters['collapse_to_transcripts'] == True:
-            geneGroups = phenotypeTable_deduplicated.loc[libraryTableGeneAnalysis.loc[:,'gene'] != 'negative_control',:].groupby([libraryTableGeneAnalysis['gene'],libraryTableGeneAnalysis['transcripts']])
+            geneGroups = phenotypeTable_deduplicated.loc[libraryTableGeneAnalysis.loc[:, 'gene'] != 'negative_control', :].groupby(
+                [libraryTableGeneAnalysis['gene'], libraryTableGeneAnalysis['transcripts']])
         else:
-            geneGroups = phenotypeTable_deduplicated.loc[libraryTableGeneAnalysis.loc[:,'gene'] != 'negative_control',:].groupby(libraryTableGeneAnalysis['gene'])
+            geneGroups = phenotypeTable_deduplicated.loc[libraryTableGeneAnalysis.loc[:, 'gene'] != 'negative_control', :].groupby(
+                libraryTableGeneAnalysis['gene'])
 
         analysisTables = []
         for analysis in exptParameters['analyses']:
             print('--' + analysis)
             sys.stdout.flush()
 
-            analysisTables.append(applyGeneScoreFunction(geneGroups, negTable, analysis, exptParameters['analyses'][analysis]))
+            analysisTables.append(applyGeneScoreFunction(
+                geneGroups, negTable, analysis, exptParameters['analyses'][analysis]))
 
-        geneTable = pd.concat(analysisTables, axis=1,sort=True).reorder_levels([1,2,0],axis=1).sort_index(axis=1)
-        geneTable.to_csv(outbase + '_genetable.txt',sep='\t')
+        geneTable = pd.concat(analysisTables, axis=1, sort=True).reorder_levels(
+            [1, 2, 0], axis=1).sort_index(axis=1)
+        geneTable.to_csv(outbase + '_genetable.txt', sep='\t')
 
-        ### collapse the gene-transcript indices into a single score for a gene by best MW p-value, where applicable
+        # collapse the gene-transcript indices into a single score for a gene by best MW p-value, where applicable
         if exptParameters['collapse_to_transcripts'] == True and 'calculate_mw' in exptParameters['analyses']:
             print('Collapsing transcript scores to gene scores')
             sys.stdout.flush()
 
             geneTableCollapsed = scoreGeneByBestTranscript(geneTable)
-            geneTableCollapsed.to_csv(outbase + '_genetable_collapsed.txt',sep='\t')
-    
+            geneTableCollapsed.to_csv(
+                outbase + '_genetable_collapsed.txt', sep='\t')
+
     if generatePlots != 'off':
         if 'calculate_ave' in exptParameters['analyses'] and 'calculate_mw' in exptParameters['analyses']:
             tempDataDict = {'library': libraryTable[sublibColumn],
                             'gene scores': geneTableCollapsed if exptParameters['collapse_to_transcripts'] else geneTable}
-                            
-            for (phenotype, replicate), gtable in geneTableCollapsed.groupby(level=[0,1], axis=1):
-                if len(replicateList) == 1 or replicate[:4] == 'ave_': #just plot averaged reps where available
-                    screen_analysis.volcanoPlot(tempDataDict, phenotype, replicate, labelHits=True)
+
+            for (phenotype, replicate), gtable in geneTableCollapsed.groupby(level=[0, 1], axis=1):
+                # just plot averaged reps where available
+                if len(replicateList) == 1 or replicate[:4] == 'ave_':
+                    screen_analysis.volcanoPlot(
+                        tempDataDict, phenotype, replicate, labelHits=True)
 
     print('Done!')
 
-#given a gene table indexed by both gene and transcript, score genes by the best m-w p-value per phenotype/replicate
+# given a gene table indexed by both gene and transcript, score genes by the best m-w p-value per phenotype/replicate
+
+
 def scoreGeneByBestTranscript(geneTable):
-    geneTableTransGroups = geneTable.reorder_levels([2,0,1],axis=1)['Mann-Whitney p-value'].reset_index().groupby('gene')
+    geneTableTransGroups = geneTable.reorder_levels(
+        [2, 0, 1], axis=1)['Mann-Whitney p-value'].reset_index().groupby('gene')
 
     bestTranscriptFrame = geneTableTransGroups.apply(getBestTranscript)
 
     tupList = []
     bestTransList = []
-    for tup, group in geneTable.groupby(level=list(range(2)),axis=1):
+    for tup, group in geneTable.groupby(level=list(range(2)), axis=1):
         tupList.append(tup)
-        curFrame = geneTable.loc[zip(bestTranscriptFrame.index,bestTranscriptFrame[tup]),tup]
+        curFrame = geneTable.loc[zip(
+            bestTranscriptFrame.index, bestTranscriptFrame[tup]), tup]
         bestTransList.append(curFrame.reset_index().set_index('gene'))
 
     return pd.concat(bestTransList, axis=1, keys=tupList, sort=True)
 
+
 def getBestTranscript(group):
-    #set the index to be transcripts and then get the index with the lowest p-value for each cell
-    return group.set_index('transcripts').drop(('gene',''),axis=1).idxmin() 
+    # set the index to be transcripts and then get the index with the lowest p-value for each cell
+    return group.set_index('transcripts').drop(('gene', ''), axis=1).idxmin()
 
 
-#return Series of counts from a counts file indexed by element id
+# return Series of counts from a counts file indexed by element id
 def readCountsFile(countsFileName):
-    countsTable = pd.read_csv(countsFileName, header=None, delimiter='\t', names=['id','counts'])
+    countsTable = pd.read_csv(
+        countsFileName, header=None, delimiter='\t', names=['id', 'counts'])
     countsTable.index = countsTable['id']
     return countsTable['counts']
 
 
-#return DataFrame of library features indexed by element id
+# return DataFrame of library features indexed by element id
 def readLibraryFile(libraryFastaFileName, elementTypeFunc, geneNameFunc, miscFuncList=None):
     elementList = []
     with open(libraryFastaFileName) as infile:
@@ -296,17 +347,18 @@ def readLibraryFile(libraryFastaFileName, elementTypeFunc, geneNameFunc, miscFun
             seqLine = infile.readline()
             if idLine[0] != '>' or seqLine == None:
                 raise ValueError('Error parsing fasta file')
-                
+
             elementList.append((idLine[1:].strip(), seqLine.strip()))
-            
+
             idLine = infile.readline()
 
     elementIds, elementSeqs = zip(*elementList)
-    libraryTable = pd.DataFrame(np.array(elementSeqs), index=np.array(elementIds), columns=['aligned_seq'], dtype='object')
+    libraryTable = pd.DataFrame(np.array(elementSeqs), index=np.array(
+        elementIds), columns=['aligned_seq'], dtype='object')
 
     libraryTable['element_type'] = elementTypeFunc(libraryTable)
     libraryTable['gene_name'] = geneNameFunc(libraryTable)
-    
+
     if miscFuncList != None:
         colList = [libraryTable]
         for miscFunc in miscFuncList:
@@ -316,15 +368,18 @@ def readLibraryFile(libraryFastaFileName, elementTypeFunc, geneNameFunc, miscFun
 
     return libraryTable
 
-#print all counts file paths, to assist with making an experiment table
+# print all counts file paths, to assist with making an experiment table
+
+
 def printCountsFilePaths(baseDirectoryPathList):
     print('Make a tab-delimited file with the following columns:')
     print('counts_file\texperiment\tcondition\treplicate_id')
     print('and the following list in the counts_file column:')
     for basePath in baseDirectoryPathList:
         for root, dirs, filenames in os.walk(basePath):
-            for filename in fnmatch.filter(filenames,'*.counts'):
+            for filename in fnmatch.filter(filenames, '*.counts'):
                 print(os.path.join(root, filename))
+
 
 def mergeCountsForExperiments(experimentFileName, libraryTable):
     exptTable = pd.read_csv(experimentFileName, delimiter='\t')
@@ -335,21 +390,24 @@ def mergeCountsForExperiments(experimentFileName, libraryTable):
     for countsFile in exptTable['counts_file']:
         countsCols.append(readCountsFile(countsFile))
 
-    countsTable = pd.concat(countsCols, axis=1, keys=exptTable['counts_file']).align(libraryTable,axis=0)[0]
-    
-    countsTable = countsTable.fillna(value = 0) #nan values are 0 values, will use nan to filter out elements later
+    countsTable = pd.concat(countsCols, axis=1, keys=exptTable['counts_file']).align(
+        libraryTable, axis=0)[0]
 
-    #print countsTable.head()
-    
+    # nan values are 0 values, will use nan to filter out elements later
+    countsTable = countsTable.fillna(value=0)
+
+    # print countsTable.head()
+
     # convert counts columns to experiments, summing when reads across multiple lanes
-    exptTuples = [(exptTable.loc[row,'experiment'],exptTable.loc[row,'condition'],exptTable.loc[row,'replicate_id']) for row in exptTable.index]
+    exptTuples = [(exptTable.loc[row, 'experiment'], exptTable.loc[row, 'condition'],
+                   exptTable.loc[row, 'replicate_id']) for row in exptTable.index]
     exptTuplesToRuns = dict()
     for i, tup in enumerate(exptTuples):
         if tup not in exptTuplesToRuns:
             exptTuplesToRuns[tup] = []
-        exptTuplesToRuns[tup].append(exptTable.loc[i,'counts_file'])
+        exptTuplesToRuns[tup].append(exptTable.loc[i, 'counts_file'])
 
-    #print exptTuplesToRuns
+    # print exptTuplesToRuns
 
     exptColumns = []
     for tup in sorted(exptTuplesToRuns.keys()):
@@ -357,200 +415,244 @@ def mergeCountsForExperiments(experimentFileName, libraryTable):
             exptColumns.append(countsTable[exptTuplesToRuns[tup][0]])
         else:
             column = countsTable[exptTuplesToRuns[tup][0]]
-            for i in range(1,len(exptTuplesToRuns[tup])):
+            for i in range(1, len(exptTuplesToRuns[tup])):
                 column += countsTable[exptTuplesToRuns[tup][i]]
 
             exptColumns.append(column)
 
-    #print len(exptColumns), exptColumns[-1]
+    # print len(exptColumns), exptColumns[-1]
 
-    exptsTable = pd.concat(exptColumns, axis = 1, keys=sorted(exptTuplesToRuns.keys()),sort=True)
-    exptsTable.columns = pd.MultiIndex.from_tuples(sorted(exptTuplesToRuns.keys()))
-    #print exptsTable
+    exptsTable = pd.concat(exptColumns, axis=1, keys=sorted(
+        exptTuplesToRuns.keys()), sort=True)
+    exptsTable.columns = pd.MultiIndex.from_tuples(
+        sorted(exptTuplesToRuns.keys()))
+    # print exptsTable
 
     #mergedTable = pd.concat([libraryTable,countsTable,exptsTable],axis=1, keys = ['library_properties','raw_counts', 'merged_experiments'])
 
     return countsTable, exptsTable
 
-#filter out reads if /all/ reads for an expt accross replicates/conditions < min_reads
-def filterCountsPerExperiment(min_reads, exptsTable,libraryTable):
+# filter out reads if /all/ reads for an expt accross replicates/conditions < min_reads
+
+
+def filterCountsPerExperiment(min_reads, exptsTable, libraryTable):
     experimentGroups = []
-    
+
     exptTuples = exptsTable.columns
 
     exptSet = set([tup[0] for tup in exptTuples])
     for expt in exptSet:
         exptDf = exptsTable[[tup for tup in exptTuples if tup[0] == expt]]
         exptDfUnderMin = (exptDf < min_reads).all(axis=1)
-        exptDfFiltered = exptDf.align(exptDfUnderMin[exptDfUnderMin == False], axis=0, join='right')[0]
+        exptDfFiltered = exptDf.align(
+            exptDfUnderMin[exptDfUnderMin == False], axis=0, join='right')[0]
         experimentGroups.append(exptDfFiltered)
-        
+
         print(expt, len(exptDfUnderMin[exptDfUnderMin == True]))
 
-    resultTable = pd.concat(experimentGroups, axis = 1, sort=True).align(libraryTable, axis=0)[0]
+    resultTable = pd.concat(experimentGroups, axis=1,
+                            sort=True).align(libraryTable, axis=0)[0]
 
     return resultTable
 
-#more flexible read filtering 
-#keep row if either both/all columns are above threshold, or if either/any column is
-#in other words, mask if any column is below threshold or only if all columns are below
+# more flexible read filtering
+# keep row if either both/all columns are above threshold, or if either/any column is
+# in other words, mask if any column is below threshold or only if all columns are below
+
+
 def filterLowCounts(countsColumns, filterType, filterThreshold):
     if filterType == 'both' or filterType == 'all':
-        failFilterColumn = countsColumns.apply(lambda row: min(row) < filterThreshold, axis = 1)
+        failFilterColumn = countsColumns.apply(
+            lambda row: min(row) < filterThreshold, axis=1)
     elif filterType == 'either' or filterType == 'any':
-        failFilterColumn = countsColumns.apply(lambda row: max(row) < filterThreshold, axis = 1)
+        failFilterColumn = countsColumns.apply(
+            lambda row: max(row) < filterThreshold, axis=1)
     else:
         raise ValueError('filter type not recognized or not implemented')
 
     resultTable = countsColumns.copy()
-    resultTable.loc[failFilterColumn,:] = np.nan
+    resultTable.loc[failFilterColumn, :] = np.nan
 
     return resultTable
 
 
-#compute phenotype scores for any given comparison of two conditions
+# compute phenotype scores for any given comparison of two conditions
 def computePhenotypeScore(counts1, counts2, libraryTable, growthValue, pseudocountBehavior, pseudocountValue, normToNegs=True):
-    combinedCounts = pd.concat([counts1,counts2],axis = 1,sort=True)
+    combinedCounts = pd.concat([counts1, counts2], axis=1, sort=True)
 
-    #pseudocount
+    # pseudocount
     if pseudocountBehavior == 'default' or pseudocountBehavior == 'zeros only':
-        defaultBehavior = lambda row: row if min(row) != 0 else row + pseudocountValue
-        combinedCountsPseudo = combinedCounts.apply(defaultBehavior, axis = 1)
+        def defaultBehavior(row): return row if min(
+            row) != 0 else row + pseudocountValue
+        combinedCountsPseudo = combinedCounts.apply(defaultBehavior, axis=1)
     elif pseudocountBehavior == 'all values':
-        combinedCountsPseudo = combinedCounts.apply(lambda row: row + pseudocountValue, axis = 1)
+        combinedCountsPseudo = combinedCounts.apply(
+            lambda row: row + pseudocountValue, axis=1)
     elif pseudocountBehavior == 'filter out':
         combinedCountsPseudo = combinedCounts.copy()
-        zeroRows = combinedCounts.apply(lambda row: min(row) <= 0, axis = 1)
-        combinedCountsPseudo.loc[zeroRows,:] = np.nan
+        zeroRows = combinedCounts.apply(lambda row: min(row) <= 0, axis=1)
+        combinedCountsPseudo.loc[zeroRows, :] = np.nan
     else:
-        raise ValueError('Pseudocount behavior not recognized or not implemented')
+        raise ValueError(
+            'Pseudocount behavior not recognized or not implemented')
 
     totalCounts = combinedCountsPseudo.sum()
     countsRatio = float(totalCounts[0])/totalCounts[1]
 
-    #compute neg control log2 enrichment
+    # compute neg control log2 enrichment
     if normToNegs == True:
-        negCounts = combinedCountsPseudo.align(libraryTable[libraryTable['gene'] == 'negative_control'],axis=0,join='inner')[0]
-        #print negCounts
+        negCounts = combinedCountsPseudo.align(
+            libraryTable[libraryTable['gene'] == 'negative_control'], axis=0, join='inner')[0]
+        # print negCounts
     else:
         negCounts = combinedCountsPseudo
-    neglog2e = negCounts.apply(calcLog2e, countsRatio=countsRatio, growthValue=1, wtLog2E=0, axis=1).median()
-    #print neglog2e
+    neglog2e = negCounts.apply(
+        calcLog2e, countsRatio=countsRatio, growthValue=1, wtLog2E=0, axis=1).median()
+    # print neglog2e
 
-    #compute phenotype scores
-    scores = combinedCountsPseudo.apply(calcLog2e, countsRatio=countsRatio, growthValue=growthValue, wtLog2E=neglog2e, axis=1)
+    # compute phenotype scores
+    scores = combinedCountsPseudo.apply(
+        calcLog2e, countsRatio=countsRatio, growthValue=growthValue, wtLog2E=neglog2e, axis=1)
 
     return scores
+
 
 def calcLog2e(row, countsRatio, growthValue, wtLog2E):
     return (np.log2(countsRatio*row[1]/row[0]) - wtLog2E) / growthValue
 
-#average replicate phenotype scores
+# average replicate phenotype scores
+
+
 def averagePhenotypeScores(scoreTable):
 
     exptTuples = scoreTable.columns
     exptsToReplicates = dict()
     for tup in exptTuples:
-        if (tup[0],tup[1]) not in exptsToReplicates:
-            exptsToReplicates[(tup[0],tup[1])] = set()
-        exptsToReplicates[(tup[0],tup[1])].add(tup[2])
+        if (tup[0], tup[1]) not in exptsToReplicates:
+            exptsToReplicates[(tup[0], tup[1])] = set()
+        exptsToReplicates[(tup[0], tup[1])].add(tup[2])
 
     averagedColumns = []
     labels = []
     for expt in exptsToReplicates:
-        exptDf = scoreTable[[(expt[0],expt[1],rep_id) for rep_id in exptsToReplicates[expt]]]
+        exptDf = scoreTable[[(expt[0], expt[1], rep_id)
+                             for rep_id in exptsToReplicates[expt]]]
         averagedColumns.append(exptDf.mean(axis=1))
-        labels.append((expt[0],expt[1],'ave_'+'_'.join(exptsToReplicates[expt])))
+        labels.append((expt[0], expt[1], 'ave_' +
+                      '_'.join(exptsToReplicates[expt])))
 
-    resultTable = pd.concat(averagedColumns, axis = 1, keys=labels,sort=True).align(scoreTable, axis=0)[0]
+    resultTable = pd.concat(averagedColumns, axis=1,
+                            keys=labels, sort=True).align(scoreTable, axis=0)[0]
     resultTable.columns = pd.MultiIndex.from_tuples(labels)
 
     return resultTable
 
-def computeGeneScores(libraryTable, scoreTable, normToNegs = True):
+
+def computeGeneScores(libraryTable, scoreTable, normToNegs=True):
     geneGroups = scoreTable.groupby(libraryTable['gene_name'])
-    
+
     scoredColumns = []
     for expt in scoreTable.columns:
         if normToNegs == True:
-            negArray = np.ma.array(data=scoreTable[expt].loc[geneGroups.groups['negative_control']].dropna(),mask=False)
+            negArray = np.ma.array(
+                data=scoreTable[expt].loc[geneGroups.groups['negative_control']].dropna(), mask=False)
         else:
-            negArray = np.ma.array(data=scoreTable[expt].dropna(),mask=False)
-        
+            negArray = np.ma.array(data=scoreTable[expt].dropna(), mask=False)
+
         colList = []
         groupList = []
         for name, group in geneGroups:
             if name == 'negative_control':
                 continue
-            colList.append(geneStats(group[expt],negArray)) #group[expt].apply(geneStats, axis = 0, negArray = negArray))
+            # group[expt].apply(geneStats, axis = 0, negArray = negArray))
+            colList.append(geneStats(group[expt], negArray))
             groupList.append(name)
-            
-        scoredColumns.append(pd.DataFrame(np.array(colList), index = groupList, columns = [('KS'),('KS_sign'),('MW')]))
-    
-    #return scoredColumns
-    return pd.concat(scoredColumns, axis = 1, keys=scoreTable.columns,sort=True)
 
-#apply gene scoring functions to pre-grouped tables of phenotypes
+        scoredColumns.append(pd.DataFrame(
+            np.array(colList), index=groupList, columns=[('KS'), ('KS_sign'), ('MW')]))
+
+    # return scoredColumns
+    return pd.concat(scoredColumns, axis=1, keys=scoreTable.columns, sort=True)
+
+# apply gene scoring functions to pre-grouped tables of phenotypes
+
+
 def applyGeneScoreFunction(groupedPhenotypeTable, negativeTable, analysis, analysisParamList):
     if analysis == 'calculate_ave':
         numToAverage = analysisParamList[0]
         if numToAverage <= 0:
             means = groupedPhenotypeTable.aggregate(np.mean)
             counts = groupedPhenotypeTable.count()
-            result = pd.concat([means,counts],axis=1,keys=['average of all phenotypes','average of all phenotypes_sgRNAcount'],sort=True)
+            result = pd.concat([means, counts], axis=1, keys=[
+                               'average of all phenotypes', 'average of all phenotypes_sgRNAcount'], sort=True)
         else:
-            means = groupedPhenotypeTable.apply(lambda x: averageBestN(x, numToAverage))
+            means = groupedPhenotypeTable.apply(
+                lambda x: averageBestN(x, numToAverage))
             counts = groupedPhenotypeTable.count()
-            result = pd.concat([means,counts],axis=1,keys=['average phenotype of strongest %d'%numToAverage, 'sgRNA count_avg'],sort=True)
+            result = pd.concat([means, counts], axis=1, keys=[
+                               'average phenotype of strongest %d' % numToAverage, 'sgRNA count_avg'], sort=True)
     elif analysis == 'calculate_mw':
-        pvals = groupedPhenotypeTable.apply(lambda x: applyMW(x, negativeTable))
+        pvals = groupedPhenotypeTable.apply(
+            lambda x: applyMW(x, negativeTable))
         counts = groupedPhenotypeTable.count()
-        result = pd.concat([pvals,counts],axis=1,keys=['Mann-Whitney p-value','sgRNA count_MW'],sort=True)
+        result = pd.concat([pvals, counts], axis=1, keys=[
+                           'Mann-Whitney p-value', 'sgRNA count_MW'], sort=True)
     elif analysis == 'calculate_nth':
         nth = analysisParamList[0]
-        pvals = groupedPhenotypeTable.aggregate(lambda x: sorted(x, key=abs, reverse=True)[nth-1] if nth <= len(x) else np.nan)
+        pvals = groupedPhenotypeTable.aggregate(lambda x: sorted(
+            x, key=abs, reverse=True)[nth-1] if nth <= len(x) else np.nan)
         counts = groupedPhenotypeTable.count()
-        result = pd.concat([pvals,counts],axis=1,keys=['%dth best score' % nth,'sgRNA count_nth best'],sort=True)
+        result = pd.concat([pvals, counts], axis=1, keys=[
+                           '%dth best score' % nth, 'sgRNA count_nth best'], sort=True)
     else:
-        raise ValueError('Analysis %s not recognized or not implemented' % analysis)
+        raise ValueError(
+            'Analysis %s not recognized or not implemented' % analysis)
 
     return result
 
+
 def averageBestN(group, numToAverage):
-    return group.apply(lambda column: np.mean(sorted(column.dropna(),key=abs,reverse=True)[:numToAverage]) if len(column.dropna()) > 0 else np.nan)
+    return group.apply(lambda column: np.mean(sorted(column.dropna(), key=abs, reverse=True)[:numToAverage]) if len(column.dropna()) > 0 else np.nan)
+
 
 def applyMW(group, negativeTable):
-    if int(sp.__version__.split('.')[1]) >= 17: #implementation of the "alternative flag":
-        return group.apply(lambda column: stats.mannwhitneyu(column.dropna().values, negativeTable[column.name].dropna().values, alternative = 'two-sided')[1] if len(column.dropna()) > 0 else np.nan)
+    # implementation of the "alternative flag":
+    if int(sp.__version__.split('.')[1]) >= 17:
+        return group.apply(lambda column: stats.mannwhitneyu(column.dropna().values, negativeTable[column.name].dropna().values, alternative='two-sided')[1] if len(column.dropna()) > 0 else np.nan)
     else:
-        return group.apply(lambda column: stats.mannwhitneyu(column.dropna().values, negativeTable[column.name].dropna().values)[1] * 2 if len(column.dropna()) > 0 else np.nan) #pre v0.17 stats.mannwhitneyu is one-tailed!!
+        # pre v0.17 stats.mannwhitneyu is one-tailed!!
+        return group.apply(lambda column: stats.mannwhitneyu(column.dropna().values, negativeTable[column.name].dropna().values)[1] * 2 if len(column.dropna()) > 0 else np.nan)
 
 
-#parse a tab-delimited file with column headers: experiment, replicate_id, G_value, K_value (calculated with martin's parse_growthdata.py)
+# parse a tab-delimited file with column headers: experiment, replicate_id, G_value, K_value (calculated with martin's parse_growthdata.py)
 def parseGKFile(gkFileName):
     gkdict = dict()
-    
-    with open(gkFileName,'rU') as infile:
+
+    with open(gkFileName, 'rU') as infile:
         for line in infile:
             if line.split('\t')[0] == 'experiment':
                 continue
             else:
                 linesplit = line.strip().split('\t')
-                gkdict[(linesplit[0],linesplit[1])] = (float(linesplit[2]),float(linesplit[3]))
+                gkdict[(linesplit[0], linesplit[1])] = (
+                    float(linesplit[2]), float(linesplit[3]))
 
     return gkdict
 
 
-
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Calculate sgRNA- and gene-level phenotypes based on sequencing read counts, as specified by the experiment config file.')
-    parser.add_argument('Config_File', help='Experiment config file specifying screen analysis settings (see accomapnying BLANK and DEMO files).')
-    parser.add_argument('Library_File_Directory', help='Directory containing reference library tables and the library_config.txt file.')
+    parser = argparse.ArgumentParser(
+        description='Calculate sgRNA- and gene-level phenotypes based on sequencing read counts, as specified by the experiment config file.')
+    parser.add_argument(
+        'Config_File', help='Experiment config file specifying screen analysis settings (see accomapnying BLANK and DEMO files).')
+    parser.add_argument('Library_File_Directory',
+                        help='Directory containing reference library tables and the library_config.txt file.')
 
-    parser.add_argument('--plot_extension', default='png', help='Image extension for plot files, or \"off\". Default is png.')
+    parser.add_argument('--plot_extension', default='png',
+                        help='Image extension for plot files, or \"off\". Default is png.')
 
     args = parser.parse_args()
     # print args
 
-    processExperimentsFromConfig(args.Config_File, args.Library_File_Directory, args.plot_extension.lower())
-
+    processExperimentsFromConfig(
+        args.Config_File, args.Library_File_Directory, args.plot_extension.lower())

--- a/process_experiments.py
+++ b/process_experiments.py
@@ -318,8 +318,9 @@ def scoreGeneByBestTranscript(geneTable):
     bestTransList = []
     for tup, group in geneTable.groupby(level=list(range(2)), axis=1):
         tupList.append(tup)
-        curFrame = geneTable.loc[zip(
-            bestTranscriptFrame.index, bestTranscriptFrame[tup]), tup]
+        curFrame = geneTable.reindex(zip(
+            bestTranscriptFrame.index, bestTranscriptFrame[tup]),
+            axis=0).loc[:, tup]
         bestTransList.append(curFrame.reset_index().set_index('gene'))
 
     return pd.concat(bestTransList, axis=1, keys=tupList, sort=True)

--- a/screen_analysis.py
+++ b/screen_analysis.py
@@ -9,27 +9,30 @@ import numpy as np
 import scipy as sp
 
 
-plotDirectory = None ##set to a directory to save figures 
+plotDirectory = None  # set to a directory to save figures
 imageExtension = 'png'
-plotWithPylab = True ##call plt.show when figures are done
+plotWithPylab = True  # call plt.show when figures are done
 figureScale = 1
 
-##Matplotlib settings
+# Matplotlib settings
 almost_black = '#111111'
 dark2 = ['#1b9e77',
-'#d95f02',
-'#7570b3',
-'#e7298a',
-'#66a61e',
-'#e6ab02',
-'#a6761d',
-'#666666']
-blue_yellow = matplotlib.colors.LinearSegmentedColormap.from_list('BuYl',[(0,'#ffff00'),(.49,'#000000'),(.51,'#000000'),(1,'#0000ff')])
-blue_yellow.set_bad('#999999',1)
-yellow_blue = matplotlib.colors.LinearSegmentedColormap.from_list('YlBu',[(0,'#0000ff'),(.49,'#000000'),(.51,'#000000'),(1,'#ffff00')])
-yellow_blue.set_bad('#999999',1)
+         '#d95f02',
+         '#7570b3',
+         '#e7298a',
+         '#66a61e',
+         '#e6ab02',
+         '#a6761d',
+         '#666666']
+blue_yellow = matplotlib.colors.LinearSegmentedColormap.from_list(
+    'BuYl', [(0, '#ffff00'), (.49, '#000000'), (.51, '#000000'), (1, '#0000ff')])
+blue_yellow.set_bad('#999999', 1)
+yellow_blue = matplotlib.colors.LinearSegmentedColormap.from_list(
+    'YlBu', [(0, '#0000ff'), (.49, '#000000'), (.51, '#000000'), (1, '#ffff00')])
+yellow_blue.set_bad('#999999', 1)
 
-plt.rcParams['font.sans-serif'] = ['Helvetica', 'Arial', 'Verdana','Bitstream Vera Sans']
+plt.rcParams['font.sans-serif'] = ['Helvetica',
+                                   'Arial', 'Verdana', 'Bitstream Vera Sans']
 plt.rcParams['font.size'] = 8
 plt.rcParams['font.weight'] = 'regular'
 plt.rcParams['text.color'] = almost_black
@@ -47,7 +50,7 @@ plt.rcParams['patch.edgecolor'] = 'none'
 plt.rcParams['patch.linewidth'] = .25
 # plt.rcParams['patch.facecolor'] = dark2_all[0]
 
-plt.rcParams['savefig.dpi']=1000
+plt.rcParams['savefig.dpi'] = 1000
 plt.rcParams['savefig.format'] = 'svg'
 
 plt.rcParams['legend.frameon'] = False
@@ -63,402 +66,444 @@ plt.rcParams['xtick.direction'] = 'out'
 plt.rcParams['xtick.color'] = almost_black
 plt.rcParams['xtick.major.width'] = axisLineWidth
 
-def loadData(experimentName, collapsedToTranscripts = True, premergedCounts = False):
-    dataDict = {'library': pd.read_csv(experimentName + '_librarytable.txt',sep='\t',header=0,index_col=0),
-    'counts': pd.read_csv(experimentName + '_mergedcountstable.txt',sep='\t',header=range(2),index_col=range(1)),
-    'phenotypes': pd.read_csv(experimentName + '_phenotypetable.txt',sep='\t',header=range(2),index_col=range(1))}
-    
+
+def loadData(experimentName, collapsedToTranscripts=True, premergedCounts=False):
+    dataDict = {'library': pd.read_csv(experimentName + '_librarytable.txt', sep='\t', header=0, index_col=0),
+                'counts': pd.read_csv(experimentName + '_mergedcountstable.txt', sep='\t', header=range(2), index_col=range(1)),
+                'phenotypes': pd.read_csv(experimentName + '_phenotypetable.txt', sep='\t', header=range(2), index_col=range(1))}
+
     if premergedCounts:
-        dataDict['premerged counts'] = pd.read_csv(experimentName + '_rawcountstable.txt',sep='\t',header=range(3),index_col=range(1))
-    
+        dataDict['premerged counts'] = pd.read_csv(
+            experimentName + '_rawcountstable.txt', sep='\t', header=range(3), index_col=range(1))
+
     if collapsedToTranscripts:
-        dataDict['transcript scores'] = pd.read_csv(experimentName + '_genetable.txt',sep='\t',header=range(3),index_col=range(2))
-        dataDict['gene scores'] = pd.read_csv(experimentName + '_genetable_collapsed.txt',sep='\t',header=range(3),index_col=range(1))
+        dataDict['transcript scores'] = pd.read_csv(
+            experimentName + '_genetable.txt', sep='\t', header=range(3), index_col=range(2))
+        dataDict['gene scores'] = pd.read_csv(
+            experimentName + '_genetable_collapsed.txt', sep='\t', header=range(3), index_col=range(1))
     else:
-        dataDict['gene scores'] = pd.read_csv(experimentName + '_genetable.txt',sep='\t',header=range(3),index_col=range(1))
-    
+        dataDict['gene scores'] = pd.read_csv(
+            experimentName + '_genetable.txt', sep='\t', header=range(3), index_col=range(1))
+
     return dataDict
 
 
-##read counts-level plotting functions
+# read counts-level plotting functions
 def countsHistogram(data, condition=None, replicate=None):
-    if not checkOptions(data, 'counts', (condition,replicate)):
+    if not checkOptions(data, 'counts', (condition, replicate)):
         return
-        
-    fig, axis = plt.subplots(figsize=(3.5*figureScale,2.5*figureScale))
+
+    fig, axis = plt.subplots(figsize=(3.5*figureScale, 2.5*figureScale))
     cleanAxes(axis)
-    
+
     axis.semilogy()
-    
-    logCounts = np.log2(data['counts'].loc[:, (condition, replicate)].fillna(0) + 1)
-    
-    axis.hist(logCounts, 
-        bins=int(len(data['counts']) ** .3), 
-        histtype='step', color=almost_black, lw=1)
-        
+
+    logCounts = np.log2(
+        data['counts'].loc[:, (condition, replicate)].fillna(0) + 1)
+
+    axis.hist(logCounts,
+              bins=int(len(data['counts']) ** .3),
+              histtype='step', color=almost_black, lw=1)
+
     ymax = axis.get_ylim()[1]
-    axis.plot([np.median(logCounts)]*2, (0.8,ymax), color='#BFBFBF', lw=.5, alpha=.5)
-    axis.text(np.median(logCounts)*.98, ymax *.90, 'median reads = {0:.0f}'.format(np.median(data['counts'].loc[:, (condition, replicate)].fillna(0))),
-        horizontalalignment='right', verticalalignment='top', fontsize=6)
-    
-    axis.set_ylim((0.9, ymax)) 
-    
-    axis.set_xlabel('{0} {1} sgRNA read counts (log2)'.format(condition, replicate))
+    axis.plot([np.median(logCounts)]*2, (0.8, ymax),
+              color='#BFBFBF', lw=.5, alpha=.5)
+    axis.text(np.median(logCounts)*.98, ymax * .90, 'median reads = {0:.0f}'.format(np.median(data['counts'].loc[:, (condition, replicate)].fillna(0))),
+              horizontalalignment='right', verticalalignment='top', fontsize=6)
+
+    axis.set_ylim((0.9, ymax))
+
+    axis.set_xlabel(
+        '{0} {1} sgRNA read counts (log2)'.format(condition, replicate))
     axis.set_ylabel('Number of sgRNAs')
-    
+
     plt.tight_layout()
     return displayFigure(fig, 'counts_hist')
-    
-def countsScatter(data, condition_x = None, replicate_x = None,
-                        condition_y = None, replicate_y = None,
-                        showAll = True, showNegatives = True, showGenes = [],
-                        colorByPhenotype_condition = None, colorByPhenotype_replicate = None):
-                            
-    if not checkOptions(data, 'counts', (condition_x,replicate_x)):
+
+
+def countsScatter(data, condition_x=None, replicate_x=None,
+                  condition_y=None, replicate_y=None,
+                  showAll=True, showNegatives=True, showGenes=[],
+                  colorByPhenotype_condition=None, colorByPhenotype_replicate=None):
+
+    if not checkOptions(data, 'counts', (condition_x, replicate_x)):
         return
-    if not checkOptions(data, 'counts', (condition_y,replicate_y)):
+    if not checkOptions(data, 'counts', (condition_y, replicate_y)):
         return
     if colorByPhenotype_condition != None and colorByPhenotype_replicate != None \
-        and not checkOptions(data, 'phenotypes', (colorByPhenotype_condition,colorByPhenotype_replicate)):
-        return 
-        
-    fig, axis = plt.subplots(figsize=(3*figureScale,3*figureScale))
+            and not checkOptions(data, 'phenotypes', (colorByPhenotype_condition, colorByPhenotype_replicate)):
+        return
+
+    fig, axis = plt.subplots(figsize=(3*figureScale, 3*figureScale))
     cleanAxes(axis)
-    
+
     if showAll:
         if colorByPhenotype_condition == None or colorByPhenotype_replicate == None:
-            axis.scatter(np.log2(data['counts'].loc[:, (condition_x, replicate_x)] + 1), 
-                np.log2(data['counts'].loc[:, (condition_y, replicate_y)] + 1), 
-                s=1.5, c=almost_black, label='all sgRNAs',
-                     rasterized=True)
+            axis.scatter(np.log2(data['counts'].loc[:, (condition_x, replicate_x)] + 1),
+                         np.log2(
+                             data['counts'].loc[:, (condition_y, replicate_y)] + 1),
+                         s=1.5, c=almost_black, label='all sgRNAs',
+                         rasterized=True)
         else:
-            result = axis.scatter(np.log2(data['counts'].loc[:, (condition_x, replicate_x)] + 1), 
-                np.log2(data['counts'].loc[:, (condition_y, replicate_y)] + 1), 
-                s=1.5, c=data['phenotypes'].loc[:, (colorByPhenotype_condition,colorByPhenotype_replicate)],
-                cmap=yellow_blue, label='all sgRNAs',
-                     rasterized=True)
-                
+            result = axis.scatter(np.log2(data['counts'].loc[:, (condition_x, replicate_x)] + 1),
+                                  np.log2(
+                                      data['counts'].loc[:, (condition_y, replicate_y)] + 1),
+                                  s=1.5, c=data['phenotypes'].loc[:, (colorByPhenotype_condition, colorByPhenotype_replicate)],
+                                  cmap=yellow_blue, label='all sgRNAs',
+                                  rasterized=True)
+
             plt.colorbar(result)
-    
+
     if showNegatives:
-        axis.scatter(np.log2(data['counts'].loc[data['library']['gene'] == 'negative_control', (condition_x, replicate_x)] + 1), 
-            np.log2(data['counts'].loc[data['library']['gene'] == 'negative_control', (condition_y, replicate_y)] + 1), 
-            s=1.5, c='#BFBFBF', label='non-targeting sgRNAs',
+        axis.scatter(np.log2(data['counts'].loc[data['library']['gene'] == 'negative_control', (condition_x, replicate_x)] + 1),
+                     np.log2(data['counts'].loc[data['library']['gene'] ==
+                             'negative_control', (condition_y, replicate_y)] + 1),
+                     s=1.5, c='#BFBFBF', label='non-targeting sgRNAs',
                      rasterized=True)
-            
+
     if showGenes and len(showGenes) != 0:
-        if isinstance(showGenes,str):
+        if isinstance(showGenes, str):
             showGenes = [showGenes]
-            
+
         geneSet = set(data['library']['gene'])
         for i, gene in enumerate(showGenes):
             if gene not in geneSet:
                 print('{0} not in dataset'.format(gene))
             else:
-                axis.scatter(np.log2(data['counts'].loc[data['library']['gene'] == gene, (condition_x, replicate_x)] + 1), 
-                    np.log2(data['counts'].loc[data['library']['gene'] == gene, (condition_y, replicate_y)] + 1), 
-                    s=3, c=dark2[i], label=gene)
-                    
+                axis.scatter(np.log2(data['counts'].loc[data['library']['gene'] == gene, (condition_x, replicate_x)] + 1),
+                             np.log2(data['counts'].loc[data['library']['gene']
+                                     == gene, (condition_y, replicate_y)] + 1),
+                             s=3, c=dark2[i], label=gene)
+
     plt.legend(loc='best', fontsize=6, handletextpad=0.005)
-    
-    axis.set_xlim((-0.2, max(axis.get_xlim()[1],axis.get_ylim()[1]))) 
-    axis.set_ylim((-0.2, max(axis.get_xlim()[1],axis.get_ylim()[1]))) 
-    
-    axis.set_xlabel('{0} {1} sgRNA read counts (log2)'.format(condition_x, replicate_x), fontsize=8)
-    axis.set_ylabel('{0} {1} sgRNA read counts (log2)'.format(condition_y, replicate_y), fontsize=8)
-    
+
+    axis.set_xlim((-0.2, max(axis.get_xlim()[1], axis.get_ylim()[1])))
+    axis.set_ylim((-0.2, max(axis.get_xlim()[1], axis.get_ylim()[1])))
+
+    axis.set_xlabel('{0} {1} sgRNA read counts (log2)'.format(
+        condition_x, replicate_x), fontsize=8)
+    axis.set_ylabel('{0} {1} sgRNA read counts (log2)'.format(
+        condition_y, replicate_y), fontsize=8)
+
     plt.tight_layout()
     return displayFigure(fig, 'counts_scatter')
-    
+
+
 def premergedCountsScatterMatrix(data, condition=None, replicate=None):
-    if not checkOptions(data, 'counts', (condition,replicate)):
+    if not checkOptions(data, 'counts', (condition, replicate)):
         return
 
     if 'premerged counts' not in data:
         print('Data must be loaded with premergedCounts = True')
         return
-       
-    dataTable = data['premerged counts'].loc[:,(condition, replicate)]
+
+    dataTable = data['premerged counts'].loc[:, (condition, replicate)]
     dataColumns = dataTable.columns
     if len(dataColumns) == 1:
-        print('Only one counts file for {0}, {1}; no scatter matrix will be generated'.format(condition, replicate))
+        print('Only one counts file for {0}, {1}; no scatter matrix will be generated'.format(
+            condition, replicate))
         return
-        
-    
-    fig, axes = plt.subplots(len(dataColumns), len(dataColumns), figsize=(len(dataColumns)*2.5,len(dataColumns)*2.5))
+
+    fig, axes = plt.subplots(len(dataColumns), len(dataColumns), figsize=(
+        len(dataColumns)*2.5, len(dataColumns)*2.5))
 
     for i, (name1, col1) in enumerate(dataTable.iteritems()):
         name1 = '{0:.30}'.format(os.path.split(name1)[-1])
         for j, (name2, col2) in enumerate(dataTable.iteritems()):
             name2 = '{0:.30}'.format(os.path.split(name2)[-1])
             if i < j:
-                cleanAxes(axes[i,j], top=False, bottom=False, left=False, right=False)
-                axes[i,j].xaxis.set_tick_params(top=False,bottom=False,labelbottom=False)
-                axes[i,j].yaxis.set_tick_params(left=False,right=False,labelleft=False)
-                
+                cleanAxes(axes[i, j], top=False, bottom=False,
+                          left=False, right=False)
+                axes[i, j].xaxis.set_tick_params(
+                    top=False, bottom=False, labelbottom=False)
+                axes[i, j].yaxis.set_tick_params(
+                    left=False, right=False, labelleft=False)
+
             elif i == j:
-                axes[i,j].hist(np.log2(col2.dropna() + 1), bins=int(len(col2) ** .3), histtype='step', color=almost_black, lw=1)
-            
-                axes[i,j].set_xlabel(name2,fontsize=6)
-                axes[i,j].set_ylabel('# sgRNAs',fontsize=6)
+                axes[i, j].hist(np.log2(col2.dropna(
+                ) + 1), bins=int(len(col2) ** .3), histtype='step', color=almost_black, lw=1)
 
-                axes[i,j].xaxis.set_tick_params(labelsize=6)
-                axes[i,j].yaxis.set_tick_params(labelsize=6)
+                axes[i, j].set_xlabel(name2, fontsize=6)
+                axes[i, j].set_ylabel('# sgRNAs', fontsize=6)
+
+                axes[i, j].xaxis.set_tick_params(labelsize=6)
+                axes[i, j].yaxis.set_tick_params(labelsize=6)
             else:
-                axes[i,j].scatter(np.log2(col2.dropna() + 1),np.log2(col1.dropna() + 1), s=2, c=almost_black, rasterized=True)
+                axes[i, j].scatter(np.log2(col2.dropna(
+                ) + 1), np.log2(col1.dropna() + 1), s=2, c=almost_black, rasterized=True)
 
-                axes[i,j].set_xlabel(name2,fontsize=6)
-                axes[i,j].set_ylabel(name1,fontsize=6)
+                axes[i, j].set_xlabel(name2, fontsize=6)
+                axes[i, j].set_ylabel(name1, fontsize=6)
 
-                axes[i,j].xaxis.set_tick_params(labelsize=6)
-                axes[i,j].yaxis.set_tick_params(labelsize=6)
-        
-        
+                axes[i, j].xaxis.set_tick_params(labelsize=6)
+                axes[i, j].yaxis.set_tick_params(labelsize=6)
+
     plt.tight_layout(pad=.05)
     return displayFigure(fig, 'premerged_counts_scatter')
 
 
-##phenotype-level plotting functions
-#not yet implemented: counts vs phenotype
+# phenotype-level plotting functions
+# not yet implemented: counts vs phenotype
 
 def phenotypeHistogram(data, phenotype=None, replicate=None):
-    if not checkOptions(data, 'phenotypes', (phenotype,replicate)):
+    if not checkOptions(data, 'phenotypes', (phenotype, replicate)):
         return
-        
-    fig, axis = plt.subplots(figsize=(3.5*figureScale,2.5*figureScale))
+
+    fig, axis = plt.subplots(figsize=(3.5*figureScale, 2.5*figureScale))
     cleanAxes(axis)
-    
+
     axis.semilogy()
-    
-    axis.hist([data['phenotypes'].loc[:, (phenotype, replicate)].dropna(), 
-                data['phenotypes'].loc[data['library']['gene'] == 'negative_control', (phenotype, replicate)].dropna()],
-        bins=int(len(data['phenotypes']) ** .3), 
-        histtype='step', color=[almost_black, '#BFBFBF'], label=['all sgRNAs', 'non-targeting sgRNAs'], lw=1)
-        
+
+    axis.hist([data['phenotypes'].loc[:, (phenotype, replicate)].dropna(),
+               data['phenotypes'].loc[data['library']['gene'] == 'negative_control', (phenotype, replicate)].dropna()],
+              bins=int(len(data['phenotypes']) ** .3),
+              histtype='step', color=[almost_black, '#BFBFBF'], label=['all sgRNAs', 'non-targeting sgRNAs'], lw=1)
+
     plt.legend(fontsize=6, loc='upper left')
-    
-    axis.set_ylim((0.9, axis.get_ylim()[1])) 
-    
+
+    axis.set_ylim((0.9, axis.get_ylim()[1]))
+
     axis.set_xlabel('{0} {1} sgRNA phenotypes'.format(phenotype, replicate))
     axis.set_ylabel('Number of sgRNAs')
-    
+
     plt.tight_layout()
     return displayFigure(fig, 'phenotype_hist')
 
-def phenotypeScatter(data, phenotype_x = None, replicate_x = None,
-                        phenotype_y = None, replicate_y = None,
-                        showAll = True, showNegatives = True, 
-                        showGenes = [], showGeneSets = {}):
-                            
-    if not checkOptions(data, 'phenotypes', (phenotype_x,replicate_x)):
+
+def phenotypeScatter(data, phenotype_x=None, replicate_x=None,
+                     phenotype_y=None, replicate_y=None,
+                     showAll=True, showNegatives=True,
+                     showGenes=[], showGeneSets={}):
+
+    if not checkOptions(data, 'phenotypes', (phenotype_x, replicate_x)):
         return
-    if not checkOptions(data, 'phenotypes', (phenotype_y,replicate_y)):
+    if not checkOptions(data, 'phenotypes', (phenotype_y, replicate_y)):
         return
-        
-    fig, axis = plt.subplots(figsize=(3*figureScale,3*figureScale))
+
+    fig, axis = plt.subplots(figsize=(3*figureScale, 3*figureScale))
     cleanAxes(axis)
-    
+
     if showAll:
-        axis.scatter(data['phenotypes'].loc[:, (phenotype_x, replicate_x)], 
-            data['phenotypes'].loc[:, (phenotype_y, replicate_y)], 
-            s=1.5, c=almost_black, label='all sgRNAs',
-             rasterized=True)
-    
+        axis.scatter(data['phenotypes'].loc[:, (phenotype_x, replicate_x)],
+                     data['phenotypes'].loc[:, (phenotype_y, replicate_y)],
+                     s=1.5, c=almost_black, label='all sgRNAs',
+                     rasterized=True)
+
     if showNegatives:
-        axis.scatter(data['phenotypes'].loc[data['library']['gene'] == 'negative_control', (phenotype_x, replicate_x)], 
-            data['phenotypes'].loc[data['library']['gene'] == 'negative_control', (phenotype_y, replicate_y)], 
-            s=1.5, c='#BFBFBF', label='non-targeting sgRNAs',
-             rasterized=True)
-            
-    i=0
+        axis.scatter(data['phenotypes'].loc[data['library']['gene'] == 'negative_control', (phenotype_x, replicate_x)],
+                     data['phenotypes'].loc[data['library']['gene'] ==
+                                            'negative_control', (phenotype_y, replicate_y)],
+                     s=1.5, c='#BFBFBF', label='non-targeting sgRNAs',
+                     rasterized=True)
+
+    i = 0
     if showGenes and len(showGenes) != 0:
-        if isinstance(showGenes,str):
+        if isinstance(showGenes, str):
             showGenes = [showGenes]
-            
+
         geneSet = set(data['library']['gene'])
         for i, gene in enumerate(showGenes):
             if gene not in geneSet:
                 print('{0} not in dataset'.format(gene))
             else:
-                axis.scatter(data['phenotypes'].loc[data['library']['gene'] == gene, (phenotype_x, replicate_x)], 
-                    data['phenotypes'].loc[data['library']['gene'] == gene, (phenotype_y, replicate_y)], 
-                    s=3, c=dark2[i], label=gene,
-                     rasterized=True)
-                    
+                axis.scatter(data['phenotypes'].loc[data['library']['gene'] == gene, (phenotype_x, replicate_x)],
+                             data['phenotypes'].loc[data['library']['gene']
+                                                    == gene, (phenotype_y, replicate_y)],
+                             s=3, c=dark2[i], label=gene,
+                             rasterized=True)
+
     if showGeneSets and len(showGeneSets) != 0:
-        if not isinstance(showGeneSets,dict) or not \
-            (isinstance(showGeneSets[showGeneSets.keys()[0]], set) or isinstance(showGeneSets[showGeneSets.keys()[0]], list)):
-            print('Gene sets must be a dictionary of {set_name: [gene list/set]} pairs')
-            
+        if not isinstance(showGeneSets, dict) or not \
+                (isinstance(showGeneSets[showGeneSets.keys()[0]], set) or isinstance(showGeneSets[showGeneSets.keys()[0]], list)):
+            print(
+                'Gene sets must be a dictionary of {set_name: [gene list/set]} pairs')
+
         else:
             for j, gs in enumerate(showGeneSets):
-                sgsTargetingSet = data['library']['gene'].apply(lambda gene: gene in showGeneSets[gs])
-                axis.scatter(data['phenotypes'].loc[sgsTargetingSet, (phenotype_x, replicate_x)], 
-                    data['phenotypes'].loc[sgsTargetingSet, (phenotype_y, replicate_y)], 
-                    s=3, c=dark2[i+j], label=gs,
-                     rasterized=True)
-                    
+                sgsTargetingSet = data['library']['gene'].apply(
+                    lambda gene: gene in showGeneSets[gs])
+                axis.scatter(data['phenotypes'].loc[sgsTargetingSet, (phenotype_x, replicate_x)],
+                             data['phenotypes'].loc[sgsTargetingSet,
+                                                    (phenotype_y, replicate_y)],
+                             s=3, c=dark2[i+j], label=gs,
+                             rasterized=True)
+
     plotGrid(axis)
-                    
+
     plt.legend(loc='best', fontsize=6, handletextpad=0.005)
-    
-    axis.set_xlabel('sgRNA {0} {1}'.format(phenotype_x, replicate_x), fontsize=8)
-    axis.set_ylabel('sgRNA {0} {1}'.format(phenotype_y, replicate_y), fontsize=8)
-    
+
+    axis.set_xlabel('sgRNA {0} {1}'.format(
+        phenotype_x, replicate_x), fontsize=8)
+    axis.set_ylabel('sgRNA {0} {1}'.format(
+        phenotype_y, replicate_y), fontsize=8)
+
     plt.tight_layout()
     return displayFigure(fig, 'phenotype_scatter')
 
+
 def sgRNAsPassingFilterHist(data, phenotype, replicate, transcripts=False):
-    if not checkOptions(data, 'phenotypes', (phenotype,replicate)):
+    if not checkOptions(data, 'phenotypes', (phenotype, replicate)):
         return
-        
-    fig, axis = plt.subplots(figsize=(3.5*figureScale,2.5*figureScale))
+
+    fig, axis = plt.subplots(figsize=(3.5*figureScale, 2.5*figureScale))
     cleanAxes(axis)
-    
+
     axis.semilogy()
-    
+
     if transcripts:
-        sgRNAsPerGene = data['phenotypes'].loc[data['library']['gene'] != 'negative_control', (phenotype, replicate)].groupby([data['library']['gene'],data['library']['transcripts']]).count()
+        sgRNAsPerGene = data['phenotypes'].loc[data['library']['gene'] != 'negative_control', (phenotype, replicate)].groupby(
+            [data['library']['gene'], data['library']['transcripts']]).count()
     else:
-        sgRNAsPerGene = data['phenotypes'].loc[data['library']['gene'] != 'negative_control', (phenotype, replicate)].groupby(data['library']['gene']).count()
-    
+        sgRNAsPerGene = data['phenotypes'].loc[data['library']['gene'] != 'negative_control', (
+            phenotype, replicate)].groupby(data['library']['gene']).count()
+
     axis.hist(sgRNAsPerGene,
-        bins=np.arange(min(sgRNAsPerGene), max(sgRNAsPerGene) + 1, 1), 
-        histtype='step', color=almost_black, lw=1)
-    
-    axis.set_ylim((0.9, axis.get_ylim()[1])) 
-    
-    axis.set_xlabel('{0} {1} sgRNAs passing filter per {2}'.format(phenotype, replicate, 'transcript' if transcripts else 'gene'))
+              bins=np.arange(min(sgRNAsPerGene), max(sgRNAsPerGene) + 1, 1),
+              histtype='step', color=almost_black, lw=1)
+
+    axis.set_ylim((0.9, axis.get_ylim()[1]))
+
+    axis.set_xlabel('{0} {1} sgRNAs passing filter per {2}'.format(
+        phenotype, replicate, 'transcript' if transcripts else 'gene'))
     axis.set_ylabel('Number of sgRNAs')
-    
+
     plt.tight_layout()
     return displayFigure(fig, 'sgRNAs_passing_filter_hist')
-    
-##gene-level plotting functions
+
+# gene-level plotting functions
+
+
 def volcanoPlot(data, phenotype=None, replicate=None, transcripts=False, showPseudo=True,
-            effectSizeLabel=None, pvalueLabel=None, hitThreshold=7,
-            labelHits = False, showGeneSets = {}, labelGeneSets = True):
-    if not checkOptions(data, 'genes', (phenotype,replicate)):
+                effectSizeLabel=None, pvalueLabel=None, hitThreshold=7,
+                labelHits=False, showGeneSets={}, labelGeneSets=True):
+    if not checkOptions(data, 'genes', (phenotype, replicate)):
         return
 
     if transcripts:
-        table = data['transcript scores'][(phenotype,replicate)].copy()
-        isPseudo = table.apply(lambda row: row.name[0][:6] == 'pseudo',axis=1)
+        table = data['transcript scores'][(phenotype, replicate)].copy()
+        isPseudo = table.apply(lambda row: row.name[0][:6] == 'pseudo', axis=1)
     else:
-        table = data['gene scores'][(phenotype,replicate)].copy()
-        isPseudo = table.apply(lambda row: row.name[:6] == 'pseudo',axis=1)
+        table = data['gene scores'][(phenotype, replicate)].copy()
+        isPseudo = table.apply(lambda row: row.name[:6] == 'pseudo', axis=1)
 
-        
     if effectSizeLabel == None:
         effectSizeLabel = getEffectSizeLabel(table)
-        
+
         if effectSizeLabel == None:
             return
-            
+
     if pvalueLabel == None:
         pvalueLabel = getPvalueLabel(table)
-        
+
         if pvalueLabel == None:
             return
 
-    discScore = lambda z,p: p * np.abs(z)
+    def discScore(z, p): return p * np.abs(z)
 
     pseudogeneScores = table[isPseudo]
     pseudoStd = np.std(pseudogeneScores[effectSizeLabel])
-    table.loc[:,'thresh'] = discScore(table[effectSizeLabel]/pseudoStd,-1*np.log10(table[pvalueLabel])) >= hitThreshold
-
+    table.loc[:, 'thresh'] = discScore(
+        table[effectSizeLabel]/pseudoStd, -1*np.log10(table[pvalueLabel])) >= hitThreshold
 
     yGenes = -1*np.log10(table[pvalueLabel])
     xGenes = table[effectSizeLabel]
 
-    fig, axis = plt.subplots(1,1, figsize=(4*figureScale,3.5*figureScale))
+    fig, axis = plt.subplots(1, 1, figsize=(4*figureScale, 3.5*figureScale))
     cleanAxes(axis)
 
-    axis.scatter(table.loc[isPseudo.ne(True)].loc[table['thresh'],effectSizeLabel], -1*np.log10(table.loc[isPseudo.ne(True)].loc[table['thresh'],pvalueLabel].values),
+    axis.scatter(table.loc[isPseudo.ne(True)].loc[table['thresh'], effectSizeLabel], -1*np.log10(table.loc[isPseudo.ne(True)].loc[table['thresh'], pvalueLabel].values),
                  s=4,
                  c='#7570b3',
-                 label = 'Gene hit',
+                 label='Gene hit',
                  rasterized=True)
 
-    axis.scatter(table.loc[isPseudo.ne(True)].loc[table['thresh'].ne(True),effectSizeLabel], -1*np.log10(table.loc[isPseudo.ne(True)].loc[table['thresh'].ne(True),pvalueLabel].values),
+    axis.scatter(table.loc[isPseudo.ne(True)].loc[table['thresh'].ne(True), effectSizeLabel], -1*np.log10(table.loc[isPseudo.ne(True)].loc[table['thresh'].ne(True), pvalueLabel].values),
                  s=4,
                  c='#999999',
-                 label = 'Gene non-hit', 
+                 label='Gene non-hit',
                  rasterized=True)
-                 
+
     if labelHits:
         for gene, row in table.loc[isPseudo.ne(True)].loc[table['thresh']].iterrows():
             if transcripts:
                 gene = ', '.join(gene)
-                
+
             axis.text(row[effectSizeLabel], -1*np.log10(row[pvalueLabel]), gene, fontsize=6,
-            horizontalalignment = 'left' if row[effectSizeLabel] > 0 else 'right', verticalalignment='center')
-            
+                      horizontalalignment='left' if row[effectSizeLabel] > 0 else 'right', verticalalignment='center')
 
     if showPseudo:
-        axis.scatter(table.loc[isPseudo.ne(False)].loc[table['thresh'],effectSizeLabel], -1*np.log10(table.loc[isPseudo.ne(False)].loc[table['thresh'],pvalueLabel].values),
+        axis.scatter(table.loc[isPseudo.ne(False)].loc[table['thresh'], effectSizeLabel], -1*np.log10(table.loc[isPseudo.ne(False)].loc[table['thresh'], pvalueLabel].values),
                      s=4,
-                     c='#d95f02', 
-                     label = 'Negative control gene hit',
+                     c='#d95f02',
+                     label='Negative control gene hit',
                      rasterized=True)
 
-        axis.scatter(table.loc[isPseudo.ne(False)].loc[table['thresh'].ne(True),effectSizeLabel], -1*np.log10(table.loc[isPseudo.ne(False)].loc[table['thresh'].ne(True),pvalueLabel].values),
+        axis.scatter(table.loc[isPseudo.ne(False)].loc[table['thresh'].ne(True), effectSizeLabel], -1*np.log10(table.loc[isPseudo.ne(False)].loc[table['thresh'].ne(True), pvalueLabel].values),
                      s=4,
-                     c='#dadaeb', 
-                     label = 'Negative control gene',
+                     c='#dadaeb',
+                     label='Negative control gene',
                      rasterized=True)
 
     if showGeneSets and len(showGeneSets) != 0:
-        if not isinstance(showGeneSets,dict) or not \
-            (isinstance(showGeneSets[showGeneSets.keys()[0]], set) or isinstance(showGeneSets[showGeneSets.keys()[0]], list)):
-            print('Gene sets must be a dictionary of {set_name: [gene list/set]} pairs')
-            
+        if not isinstance(showGeneSets, dict) or not \
+                (isinstance(showGeneSets[showGeneSets.keys()[0]], set) or isinstance(showGeneSets[showGeneSets.keys()[0]], list)):
+            print(
+                'Gene sets must be a dictionary of {set_name: [gene list/set]} pairs')
+
         else:
             for i, gs in enumerate(showGeneSets):
-                sgsTargetingSet = data['library']['gene'].apply(lambda gene: gene in showGeneSets[gs])
-                axis.scatter(table.loc[showGeneSets[gs], effectSizeLabel], 
-                    -1*np.log10(table.loc[showGeneSets[gs],pvalueLabel]), 
-                    s=6, c=dark2[i], label=gs)
-                    
+                sgsTargetingSet = data['library']['gene'].apply(
+                    lambda gene: gene in showGeneSets[gs])
+                axis.scatter(table.loc[showGeneSets[gs], effectSizeLabel],
+                             -1*np.log10(table.loc[showGeneSets[gs], pvalueLabel]),
+                             s=6, c=dark2[i], label=gs)
+
                 if labelGeneSets:
                     for gene, row in table.loc[showGeneSets[gs]].iterrows():
                         if transcripts:
                             gene = ', '.join(gene)
-                
+
                         axis.text(row[effectSizeLabel], -1*np.log10(row[pvalueLabel]), gene, fontsize=6,
-                        horizontalalignment = 'left' if row[effectSizeLabel] > 0 else 'right', verticalalignment='center')
+                                  horizontalalignment='left' if row[effectSizeLabel] > 0 else 'right', verticalalignment='center')
 
     plotGrid(axis, vert_origin=True, horiz_origin=False, unity=False)
 
     ymax = np.ceil(max(yGenes)) * 1.02
     xmin = min(xGenes) * 1.05
     xmax = max(xGenes) * 1.05
-    
-    axis.plot(np.linspace(xmin,xmax,1000),np.abs(hitThreshold/np.linspace(xmin/pseudoStd,xmax/pseudoStd,1000)),'k--', lw=.5)
 
-    axis.set_xlim((xmin,xmax))
-    axis.set_ylim((0,ymax))
+    axis.plot(np.linspace(xmin, xmax, 1000), np.abs(hitThreshold /
+              np.linspace(xmin/pseudoStd, xmax/pseudoStd, 1000)), 'k--', lw=.5)
 
-    axis.set_xlabel('{3} {0} {1} ({2})'.format(phenotype, replicate, effectSizeLabel, 'gene' if not transcripts else 'transcript'),fontsize=8)
-    axis.set_ylabel('-log10 {0}'.format(pvalueLabel,fontsize=8))
-    
+    axis.set_xlim((xmin, xmax))
+    axis.set_ylim((0, ymax))
+
+    axis.set_xlabel('{3} {0} {1} ({2})'.format(phenotype, replicate,
+                    effectSizeLabel, 'gene' if not transcripts else 'transcript'), fontsize=8)
+    axis.set_ylabel('-log10 {0}'.format(pvalueLabel, fontsize=8))
+
     plt.legend(loc='best', fontsize=6, handletextpad=0.005)
 
     plt.tight_layout()
     return displayFigure(fig, 'volcano_plot')
 
-##utility functions
+# utility functions
+
+
 def checkOptions(data, graphType, optionTuple):
     if optionTuple[0] == None or optionTuple[1] == None:
         listOptions(data, graphType)
         return False
-        
+
     if graphType == 'counts':
-        colTups = set([colname[:2] for colname, col in data['counts'].iteritems()])
+        colTups = set([colname[:2]
+                      for colname, col in data['counts'].iteritems()])
     elif graphType == 'phenotypes':
-        colTups = set([colname[:2] for colname, col in data['phenotypes'].iteritems()])
+        colTups = set([colname[:2]
+                      for colname, col in data['phenotypes'].iteritems()])
     elif graphType == 'genes':
-        colTups = set([colname[:2] for colname, col in data['gene scores'].iteritems()])
+        colTups = set([colname[:2]
+                      for colname, col in data['gene scores'].iteritems()])
     else:
         print('Graph type not recognized')
         return False
@@ -466,118 +511,136 @@ def checkOptions(data, graphType, optionTuple):
     if optionTuple in colTups:
         return True
     else:
-        print('{0} {1} not recognized'.format(optionTuple[0],optionTuple[1]))
+        print('{0} {1} not recognized'.format(optionTuple[0], optionTuple[1]))
         listOptions(data, graphType)
         return False
+
 
 def listOptions(data, graphType):
     if graphType == 'counts':
         print('Condition and Replicate options are:')
-        print('\n'.join(['{0:15}\t{1}'.format(colname[0],colname[1]) for colname, col in data['counts'].iteritems()]))
-        
+        print('\n'.join(['{0:15}\t{1}'.format(colname[0], colname[1])
+              for colname, col in data['counts'].iteritems()]))
+
     elif graphType == 'phenotypes':
         print('Phenotype and Replicate options are:')
-        print('\n'.join(['{0:15}\t{1}'.format(colname[0],colname[1]) for colname, col in data['phenotypes'].iteritems()]))
-        
+        print('\n'.join(['{0:15}\t{1}'.format(colname[0], colname[1])
+              for colname, col in data['phenotypes'].iteritems()]))
+
     elif graphType == 'genes':
-        colTups = sorted(list(set([colname[:2] for colname, col in data['gene scores'].iteritems()])))
+        colTups = sorted(
+            list(set([colname[:2] for colname, col in data['gene scores'].iteritems()])))
         print('Phenotype and Replicate options are:')
-        print('\n'.join(['{0:15}\t{1}'.format(colname[0],colname[1]) for colname in colTups]))
-        
+        print('\n'.join(['{0:15}\t{1}'.format(
+            colname[0], colname[1]) for colname in colTups]))
+
     else:
         print('Graph type not recognized')
-    
+
+
 def getEffectSizeLabel(table):
-    effectColLabels = [colname for colname, col in table.iteritems() if colname[:7] == 'average']
-    
+    effectColLabels = [colname for colname,
+                       col in table.iteritems() if colname[:7] == 'average']
+
     if len(effectColLabels) == 0:
         print('No gene effect size data columns found')
         return None
-        
+
     elif len(effectColLabels) > 1:
-        print('Multiple effect size data columns found, please specifiy one: ' + ', '.join(effectColLabels))
+        print('Multiple effect size data columns found, please specifiy one: ' +
+              ', '.join(effectColLabels))
         return None
-        
+
     else:
         return effectColLabels[0]
-        
+
+
 def getPvalueLabel(table):
-    pvalColLabels = [colname for colname, col in table.iteritems() if colname == 'Mann-Whitney p-value']
-    
+    pvalColLabels = [colname for colname, col in table.iteritems(
+    ) if colname == 'Mann-Whitney p-value']
+
     if len(pvalColLabels) == 0:
         print('No p-value data columns found')
         return None
-        
+
     elif len(pvalColLabels) > 1:
-        print('Multiple p-value data columns found, please specifiy one: ' + ', '.join(effectColLabels))
+        print('Multiple p-value data columns found, please specifiy one: ' +
+              ', '.join(effectColLabels))
         return None
-        
+
     else:
         return pvalColLabels[0]
-        
+
+
 def displayFigure(fig, savetitle=''):
     if plotWithPylab:
         plt.show(fig)
-        
+
     if plotDirectory != None:
-        figNums = [int(fileName.split('_fig_')[0]) for fileName in os.listdir(plotDirectory) if len(fileName.split('_fig_')) >= 2]
+        figNums = [int(fileName.split('_fig_')[0]) for fileName in os.listdir(
+            plotDirectory) if len(fileName.split('_fig_')) >= 2]
         if len(figNums) == 0:
             nextFigNum = 0
         else:
             nextFigNum = max(figNums) + 1
 
-        fullTitle =  os.path.join(plotDirectory,'{0:03d}_fig_{1}.{2}'.format(nextFigNum, savetitle, imageExtension))
+        fullTitle = os.path.join(plotDirectory, '{0:03d}_fig_{1}.{2}'.format(
+            nextFigNum, savetitle, imageExtension))
         print(fullTitle)
         fig.savefig(fullTitle, dpi=1000)
-        plt.close(fig) 
-        
+        plt.close(fig)
+
         return fullTitle
-        
+
     if plotDirectory == None and not plotWithPylab:
         print('Must be in pylab and/or set a plot directory to display figures')
-        
-        plt.close(fig) 
-        
-def changeDisplayFigureSettings(newDirectory=None, newImageExtension = 'png', newPlotWithPylab = True, newFigureScale = 1):
+
+        plt.close(fig)
+
+
+def changeDisplayFigureSettings(newDirectory=None, newImageExtension='png', newPlotWithPylab=True, newFigureScale=1):
     global plotDirectory
     plotDirectory = newDirectory
-    
+
     global imageExtension
     imageExtension = newImageExtension
-    
+
     global plotWithPylab
     plotWithPylab = newPlotWithPylab
-    
+
     global figureScale
     figureScale = newFigureScale
-    
-def plotGrid(axis, vert_origin = True, horiz_origin=True, unity=True):
+
+
+def plotGrid(axis, vert_origin=True, horiz_origin=True, unity=True):
     ylim = axis.get_ylim()
     xlim = axis.get_xlim()
     if vert_origin:
-        axis.plot((0,0), ylim, color='#BFBFBF', lw=.5, alpha=.5) 
+        axis.plot((0, 0), ylim, color='#BFBFBF', lw=.5, alpha=.5)
     if horiz_origin:
-        axis.plot(xlim,(0,0), color='#BFBFBF', lw=.5, alpha=.5) 
+        axis.plot(xlim, (0, 0), color='#BFBFBF', lw=.5, alpha=.5)
     if unity:
         xmin = min(xlim[0], ylim[0])
         xmax = max(xlim[1], ylim[1])
-        axis.plot((xmin,xmax),(xmin,xmax), color='#BFBFBF', lw=.5, alpha=.5) 
-        
+        axis.plot((xmin, xmax), (xmin, xmax), color='#BFBFBF', lw=.5, alpha=.5)
+
     axis.set_ylim(ylim)
     axis.set_xlim(xlim)
 
-#adapted from http://nbviewer.ipython.org/github/cs109/content/blob/master/lec_03_statistical_graphs.ipynb    
+# adapted from http://nbviewer.ipython.org/github/cs109/content/blob/master/lec_03_statistical_graphs.ipynb
+
+
 def cleanAxes(axis, top=False, right=False, bottom=True, left=True):
     axis.spines['top'].set_visible(top)
     axis.spines['right'].set_visible(right)
     axis.spines['left'].set_visible(left)
     axis.spines['bottom'].set_visible(bottom)
 
-    #turn off all ticks
+    # turn off all ticks
     axis.yaxis.set_ticks_position('none')
     axis.xaxis.set_ticks_position('none')
 
-    #now re-enable visibles
+    # now re-enable visibles
     if top:
         axis.xaxis.tick_top()
     if bottom:


### PR DESCRIPTION
The python files have inconsistent use of spaces and tabs that fails when I run it on my system (sherlock computing cluster at Stanford with python/3.6.1). I have fixed this with the command "autopep8 -i *.py" to conform to PEP8 standards.

In addition, we often use sequence files with the ending ".fq.gz" which is not recognized by fastqgz_to_counts.py. I have added this filetype.